### PR TITLE
feat: support iterators and async iterators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ jobs:
 
     - stage: test
       name: electron
-      before_script: export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
+      services:
+        - xvfb
       script:
         - npm run test:electron
         - npm run test:electron-renderer

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "license": "MIT",
   "dependencies": {
     "buffer": "^5.2.1",
-    "is-buffer": "^2.0.3",
     "is-electron": "^2.2.0",
     "is-pull-stream": "0.0.0",
     "is-stream": "^2.0.0",

--- a/src/files/add-input-validation.js
+++ b/src/files/add-input-validation.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const kindOf = require('kind-of')
-const isStream = require('is-stream')
 const { isSource } = require('is-pull-stream')
-const isBuffer = require('is-buffer')
 
 const validateAddInput = (input) => {
-  // Buffer|ReadableStream|PullStream|File
-  const isPrimitive = obj => isBuffer(obj) || isStream.readable(obj) || isSource(obj) || kindOf(obj) === 'file'
+  // PullStream|File|Iterator|AsyncIterator
+  const isPrimitive = (obj) => isSource(obj) || kindOf(obj) === 'file' || obj[Symbol.iterator] || obj[Symbol.asyncIterator]
 
   // An object like { content?, path? }, where content isBufferOrStream and path isString
   const isContentObject = obj => {
@@ -24,7 +22,7 @@ const validateAddInput = (input) => {
   if (isInput(input) || (Array.isArray(input) && input.every(isInput))) {
     return true
   } else {
-    throw new Error(`Input not supported. Expected Buffer|ReadableStream|PullStream|File|Array<Object> got ${kindOf(input)}. Check the documentation for more info https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md#add`)
+    throw new Error(`Input not supported. Expected Buffer|ReadableStream|PullStream|File|Array<Object>| got ${kindOf(input)}. Check the documentation for more info https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md#add`)
   }
 }
 

--- a/test/files/add-input-validation.spec.js
+++ b/test/files/add-input-validation.spec.js
@@ -39,6 +39,15 @@ describe('add-input-validation', function () {
     expect(validate([Buffer.from('test'), Buffer.from('test')])).to.be.true()
     expect(validate([new Readable(), new Readable()])).to.be.true()
     expect(validate([empty(), empty()])).to.be.true()
+    expect(validate([async function * (){}()])).to.be.true()
+    expect(validate([{
+      [Symbol.asyncIterator]: () => {},
+      next: () => {}
+    }])).to.be.true()
+    expect(validate([{
+      [Symbol.iterator]: () => {},
+      next: () => {}
+    }])).to.be.true()
 
     if (supportsFileReader) {
       const file = new self.File(['test'], 'test.txt', { type: 'text/plain' })
@@ -51,6 +60,36 @@ describe('add-input-validation', function () {
     expect(validate({ path: '/path', content: Buffer.from('test') })).to.be.true()
     expect(validate({ content: new Readable() })).to.be.true()
     expect(validate({ content: empty() })).to.be.true()
+    expect(validate({ content: async function * (){}() })).to.be.true()
+    expect(validate({ content: {
+      [Symbol.asyncIterator]: () => {},
+      next: () => {}
+    }})).to.be.true()
+    expect(validate({ content: {
+      [Symbol.iterator]: () => {},
+      next: () => {}
+    }})).to.be.true()
+
+    if (supportsFileReader) {
+      expect(validate({ content: new Readable() })).to.be.true()
+    }
+  })
+
+  it('validates correct form array of of object input', function () {
+    expect(validate([{ path: '/path' }])).to.be.true()
+    expect(validate([{ path: '/path', content: Buffer.from('test') }])).to.be.true()
+    expect(validate([{ content: new Readable() }])).to.be.true()
+    expect(validate([{ content: empty() }])).to.be.true()
+    expect(validate([{ content: async function * (){}() }])).to.be.true()
+    expect(validate([{ content: {
+      [Symbol.asyncIterator]: () => {},
+      next: () => {}
+    }}])).to.be.true()
+    expect(validate([{ content: {
+      [Symbol.iterator]: () => {},
+      next: () => {}
+    }}])).to.be.true()
+
     if (supportsFileReader) {
       expect(validate({ content: new Readable() })).to.be.true()
     }

--- a/test/files/add-input-validation.spec.js
+++ b/test/files/add-input-validation.spec.js
@@ -19,7 +19,7 @@ describe('add-input-validation', function () {
     expect(validate(Buffer.from(('test')))).to.be.true()
     expect(validate(new Readable())).to.be.true()
     expect(validate(empty())).to.be.true()
-    expect(validate(async function * (){}())).to.be.true()
+    expect(validate(async function * () {}())).to.be.true()
     expect(validate({
       [Symbol.asyncIterator]: () => {},
       next: () => {}
@@ -39,7 +39,7 @@ describe('add-input-validation', function () {
     expect(validate([Buffer.from('test'), Buffer.from('test')])).to.be.true()
     expect(validate([new Readable(), new Readable()])).to.be.true()
     expect(validate([empty(), empty()])).to.be.true()
-    expect(validate([async function * (){}()])).to.be.true()
+    expect(validate([(async function * () {}())])).to.be.true()
     expect(validate([{
       [Symbol.asyncIterator]: () => {},
       next: () => {}
@@ -60,15 +60,15 @@ describe('add-input-validation', function () {
     expect(validate({ path: '/path', content: Buffer.from('test') })).to.be.true()
     expect(validate({ content: new Readable() })).to.be.true()
     expect(validate({ content: empty() })).to.be.true()
-    expect(validate({ content: async function * (){}() })).to.be.true()
+    expect(validate({ content: (async function * () {}()) })).to.be.true()
     expect(validate({ content: {
       [Symbol.asyncIterator]: () => {},
       next: () => {}
-    }})).to.be.true()
+    } })).to.be.true()
     expect(validate({ content: {
       [Symbol.iterator]: () => {},
       next: () => {}
-    }})).to.be.true()
+    } })).to.be.true()
 
     if (supportsFileReader) {
       expect(validate({ content: new Readable() })).to.be.true()
@@ -80,15 +80,15 @@ describe('add-input-validation', function () {
     expect(validate([{ path: '/path', content: Buffer.from('test') }])).to.be.true()
     expect(validate([{ content: new Readable() }])).to.be.true()
     expect(validate([{ content: empty() }])).to.be.true()
-    expect(validate([{ content: async function * (){}() }])).to.be.true()
+    expect(validate([{ content: (async function * () {}()) }])).to.be.true()
     expect(validate([{ content: {
       [Symbol.asyncIterator]: () => {},
       next: () => {}
-    }}])).to.be.true()
+    } }])).to.be.true()
     expect(validate([{ content: {
       [Symbol.iterator]: () => {},
       next: () => {}
-    }}])).to.be.true()
+    } }])).to.be.true()
 
     if (supportsFileReader) {
       expect(validate({ content: new Readable() })).to.be.true()

--- a/test/files/add-input-validation.spec.js
+++ b/test/files/add-input-validation.spec.js
@@ -19,6 +19,15 @@ describe('add-input-validation', function () {
     expect(validate(Buffer.from(('test')))).to.be.true()
     expect(validate(new Readable())).to.be.true()
     expect(validate(empty())).to.be.true()
+    expect(validate(async function * (){}())).to.be.true()
+    expect(validate({
+      [Symbol.asyncIterator]: () => {},
+      next: () => {}
+    })).to.be.true()
+    expect(validate({
+      [Symbol.iterator]: () => {},
+      next: () => {}
+    })).to.be.true()
 
     if (supportsFileReader) {
       const file = new self.File(['test'], 'test.txt', { type: 'text/plain' })

--- a/test/files/add-input-validation.spec.js
+++ b/test/files/add-input-validation.spec.js
@@ -14,6 +14,8 @@ const expect = chai.expect
 
 describe('add-input-validation', function () {
   it('validates correct primitive input types', function () {
+    expect(validate('Hello world')).to.be.true()
+    expect(validate([0, 1, 2, 3])).to.be.true()
     expect(validate(Buffer.from(('test')))).to.be.true()
     expect(validate(new Readable())).to.be.true()
     expect(validate(empty())).to.be.true()
@@ -47,10 +49,8 @@ describe('add-input-validation', function () {
 
   it('should throw with bad input', function () {
     const regex = /Input not supported/
-    expect(() => validate('test')).throw(regex)
     expect(() => validate(2)).throw(regex)
     expect(() => validate({ path: 3 })).throw(regex)
-    expect(() => validate({ path: 'path', content: 'test' })).throw(regex)
     expect(() => validate({ path: 'path', content: 2 })).throw(regex)
     expect(() => validate({})).throw(regex)
   })


### PR DESCRIPTION
This allows us to accept async interators as arguments to `ipfs.add` and friends.

It also allows adding plain old js things like strings and arrays, so hooray for that.