### PR TITLE
feat: add normalise input function

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "buffer": "^5.2.1",
+    "err-code": "^2.0.0",
     "is-buffer": "^2.0.3",
     "is-electron": "^2.2.0",
     "is-pull-stream": "0.0.0",
@@ -36,9 +37,10 @@
   },
   "devDependencies": {
     "aegir": "^20.0.0",
+    "async-iterator-all": "^1.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "electron": "^5.0.7",
+    "electron": "^6.0.6",
     "electron-mocha": "^8.0.3",
     "pull-stream": "^3.6.13"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "is-pull-stream": "0.0.0",
     "is-stream": "^2.0.0",
     "kind-of": "^6.0.2",
+    "pull-stream-to-async-iterator": "^1.0.2",
     "readable-stream": "^3.4.0"
   },
   "devDependencies": {

--- a/src/files/normalise-input.js
+++ b/src/files/normalise-input.js
@@ -1,0 +1,233 @@
+'use strict'
+
+const errCode = require('err-code')
+const { Buffer } = require('buffer')
+
+/*
+ * Transform one of:
+ *
+ * ```
+ * Buffer|ArrayBuffer|TypedArray
+ * Blob|File
+ * { path, content: Blob }
+ * { path, content: String }
+ * { path, content: Iterable<Number> }
+ * { path, content: Iterable<Buffer> }
+ * { path, content: Iterable<Iterable<Number>> }
+ * { path, content: AsyncIterable<Iterable<Number>> }
+ * String
+ * Iterable<Number>
+ * Iterable<Buffer>
+ * Iterable<Blob>
+ * Iterable<{ path, content: Buffer }>
+ * Iterable<{ path, content: Blob }>
+ * Iterable<{ path, content: Iterable<Number> }>
+ * Iterable<{ path, content: AsyncIterable<Buffer> }>
+ * AsyncIterable<Buffer>
+ * AsyncIterable<{ path, content: Buffer }>
+ * AsyncIterable<{ path, content: Blob }>
+ * AsyncIterable<{ path, content: Iterable<Buffer> }>
+ * AsyncIterable<{ path, content: AsyncIterable<Buffer> }>
+ * ```
+ * Into:
+ *
+ * ```
+ * AsyncIterable<{ path, content: AsyncIterable<Buffer> }>
+ * ```
+ *
+ * @param input Object
+ * @return AsyncInterable<{ path, content: AsyncIterable<Buffer> }>
+ */
+module.exports = function normaliseInput (input) {
+  // must give us something
+  if (input === null || input === undefined) {
+    throw errCode(new Error(`Unexpected input: ${input}`, 'ERR_UNEXPECTED_INPUT'))
+  }
+
+  // { path, content: ? }
+  if (isFileObject(input)) {
+    return (async function * () { // eslint-disable-line require-await
+      yield toFileObject(input)
+    })()
+  }
+
+  // String
+  if (typeof input === 'string' || input instanceof String) {
+    return (async function * () { // eslint-disable-line require-await
+      yield toFileObject(input)
+    })()
+  }
+
+  // Buffer|ArrayBuffer|TypedArray
+  // Blob|File
+  if (isBytes(input) || isBloby(input)) {
+    return (async function * () { // eslint-disable-line require-await
+      yield toFileObject(input)
+    })()
+  }
+
+  // Iterable<?>
+  if (input[Symbol.iterator]) {
+    // Iterable<Number>
+    if (!isNaN(input[0])) {
+      return (async function * () { // eslint-disable-line require-await
+        yield toFileObject([input])
+      })()
+    }
+
+    // Iterable<Buffer>
+    // Iterable<Blob>
+    return (async function * () { // eslint-disable-line require-await
+      for (const chunk of input) {
+        yield toFileObject(chunk)
+      }
+    })()
+  }
+
+  // AsyncIterable<?>
+  if (input[Symbol.asyncIterator]) {
+    return (async function * () { // eslint-disable-line require-await
+      for await (const chunk of input) {
+        yield toFileObject(chunk)
+      }
+    })()
+  }
+
+  throw errCode(new Error('Unexpected input: ' + typeof input), 'ERR_UNEXPECTED_INPUT')
+}
+
+function toFileObject (input) {
+  return {
+    path: input.path || '',
+    content: toAsyncIterable(input.content || input)
+  }
+}
+
+function toAsyncIterable (input) {
+  // Buffer|ArrayBuffer|TypedArray|array of bytes
+  if (isBytes(input)) {
+    return (async function * () { // eslint-disable-line require-await
+      yield toBuffer(input)
+    })()
+  }
+
+  if (typeof input === 'string' || input instanceof String) {
+    return (async function * () { // eslint-disable-line require-await
+      yield toBuffer(input)
+    })()
+  }
+
+  // Blob|File
+  if (isBloby(input)) {
+    return blobToAsyncGenerator(input)
+  }
+
+  // Iterator<?>
+  if (input[Symbol.iterator]) {
+    if (!isNaN(input[0])) {
+      return (async function * () { // eslint-disable-line require-await
+        yield toBuffer(input)
+      })()
+    }
+
+    return (async function * () { // eslint-disable-line require-await
+      for (const chunk of input) {
+        yield toBuffer(chunk)
+      }
+    })()
+  }
+
+  // AsyncIterable<?>
+  if (input[Symbol.asyncIterator]) {
+    return (async function * () {
+      for await (const chunk of input) {
+        yield toBuffer(chunk)
+      }
+    })()
+  }
+
+  throw errCode(new Error(`Unexpected input: ${input}`, 'ERR_UNEXPECTED_INPUT'))
+}
+
+function toBuffer (chunk) {
+  if (isBytes(chunk)) {
+    return chunk
+  }
+
+  if (typeof chunk === 'string' || chunk instanceof String) {
+    return Buffer.from(chunk)
+  }
+
+  if (Array.isArray(chunk)) {
+    return Buffer.from(chunk)
+  }
+
+  throw new Error('Unexpected input: ' + typeof chunk)
+}
+
+function isBytes (obj) {
+  return Buffer.isBuffer(obj) || ArrayBuffer.isView(obj) || obj instanceof ArrayBuffer
+}
+
+function isBloby (obj) {
+  return typeof Blob !== 'undefined' && obj instanceof global.Blob
+}
+
+// An object with a path or content property
+function isFileObject (obj) {
+  return typeof obj === 'object' && (obj.path || obj.content)
+}
+
+function blobToAsyncGenerator (blob) {
+  if (typeof blob.stream === 'function') {
+    // firefox < 69 does not support blob.stream()
+    return streamBlob(blob)
+  }
+
+  return readBlob(blob)
+}
+
+async function * streamBlob (blob) {
+  const reader = blob.stream().getReader()
+
+  while (true) {
+    const result = await reader.read()
+
+    if (result.done) {
+      return
+    }
+
+    yield result.value
+  }
+}
+
+async function * readBlob (blob, options) {
+  options = options || {}
+
+  const reader = new global.FileReader()
+  const chunkSize = options.chunkSize || 1024 * 1024
+  let offset = options.offset || 0
+
+  const getNextChunk = () => new Promise((resolve, reject) => {
+    reader.onloadend = e => {
+      const data = e.target.result
+      resolve(data.byteLength === 0 ? null : data)
+    }
+    reader.onerror = reject
+
+    const end = offset + chunkSize
+    const slice = blob.slice(offset, end)
+    reader.readAsArrayBuffer(slice)
+    offset = end
+  })
+
+  while (true) {
+    const data = await getNextChunk()
+
+    if (data == null) {
+      return
+    }
+
+    yield Buffer.from(data)
+  }
+}

--- a/src/files/normalise-input.js
+++ b/src/files/normalise-input.js
@@ -2,32 +2,53 @@
 
 const errCode = require('err-code')
 const { Buffer } = require('buffer')
+const pullStreamToIterable = require('pull-stream-to-async-iterator')
 
 /*
  * Transform one of:
  *
  * ```
- * Buffer|ArrayBuffer|TypedArray
- * Blob|File
- * { path, content: Blob }
- * { path, content: String }
- * { path, content: Iterable<Number> }
- * { path, content: Iterable<Buffer> }
- * { path, content: Iterable<Iterable<Number>> }
- * { path, content: AsyncIterable<Iterable<Number>> }
- * String
- * Iterable<Number>
- * Iterable<Buffer>
- * Iterable<Blob>
- * Iterable<{ path, content: Buffer }>
- * Iterable<{ path, content: Blob }>
- * Iterable<{ path, content: Iterable<Number> }>
- * Iterable<{ path, content: AsyncIterable<Buffer> }>
- * AsyncIterable<Buffer>
- * AsyncIterable<{ path, content: Buffer }>
- * AsyncIterable<{ path, content: Blob }>
- * AsyncIterable<{ path, content: Iterable<Buffer> }>
- * AsyncIterable<{ path, content: AsyncIterable<Buffer> }>
+ * Bytes (Buffer|ArrayBuffer|TypedArray) [single file]
+ * Bloby (Blob|File) [single file]
+ * String [single file]
+ * { path, content: Bytes } [single file]
+ * { path, content: Bloby } [single file]
+ * { path, content: String } [single file]
+ * { path, content: Iterable<Number> } [single file]
+ * { path, content: Iterable<Bytes> } [single file]
+ * { path, content: AsyncIterable<Bytes> } [single file]
+ * { path, content: PullStream<Bytes> } [single file]
+ * Iterable<Number> [single file]
+ * Iterable<Bytes> [single file]
+ * Iterable<Bloby> [multiple files]
+ * Iterable<String> [multiple files]
+ * Iterable<{ path, content: Bytes }> [multiple files]
+ * Iterable<{ path, content: Bloby }> [multiple files]
+ * Iterable<{ path, content: String }> [multiple files]
+ * Iterable<{ path, content: Iterable<Number> }> [multiple files]
+ * Iterable<{ path, content: Iterable<Bytes> }> [multiple files]
+ * Iterable<{ path, content: AsyncIterable<Bytes> }> [multiple files]
+ * Iterable<{ path, content: PullStream<Bytes> }> [multiple files]
+ * AsyncIterable<Bytes> [single file]
+ * AsyncIterable<Bloby> [multiple files]
+ * AsyncIterable<String> [multiple files]
+ * AsyncIterable<{ path, content: Bytes }> [multiple files]
+ * AsyncIterable<{ path, content: Bloby }> [multiple files]
+ * AsyncIterable<{ path, content: String }> [multiple files]
+ * AsyncIterable<{ path, content: Iterable<Number> }> [multiple files]
+ * AsyncIterable<{ path, content: Iterable<Bytes> }> [multiple files]
+ * AsyncIterable<{ path, content: AsyncIterable<Bytes> }> [multiple files]
+ * AsyncIterable<{ path, content: PullStream<Bytes> }> [multiple files]
+ * PullStream<Bytes> [single file]
+ * PullStream<Bloby> [multiple files]
+ * PullStream<String> [multiple files]
+ * PullStream<{ path, content: Bytes }> [multiple files]
+ * PullStream<{ path, content: Bloby }> [multiple files]
+ * PullStream<{ path, content: String }> [multiple files]
+ * PullStream<{ path, content: Iterable<Number> }> [multiple files]
+ * PullStream<{ path, content: Iterable<Bytes> }> [multiple files]
+ * PullStream<{ path, content: AsyncIterable<Bytes> }> [multiple files]
+ * PullStream<{ path, content: PullStream<Bytes> }> [multiple files]
  * ```
  * Into:
  *
@@ -42,13 +63,6 @@ module.exports = function normaliseInput (input) {
   // must give us something
   if (input === null || input === undefined) {
     throw errCode(new Error(`Unexpected input: ${input}`, 'ERR_UNEXPECTED_INPUT'))
-  }
-
-  // { path, content: ? }
-  if (isFileObject(input)) {
-    return (async function * () { // eslint-disable-line require-await
-      yield toFileObject(input)
-    })()
   }
 
   // String
@@ -68,28 +82,104 @@ module.exports = function normaliseInput (input) {
 
   // Iterable<?>
   if (input[Symbol.iterator]) {
-    // Iterable<Number>
-    if (!isNaN(input[0])) {
-      return (async function * () { // eslint-disable-line require-await
-        yield toFileObject([input])
-      })()
-    }
-
-    // Iterable<Buffer>
-    // Iterable<Blob>
     return (async function * () { // eslint-disable-line require-await
-      for (const chunk of input) {
-        yield toFileObject(chunk)
+      const iterator = input[Symbol.iterator]()
+      const first = iterator.next()
+      if (first.done) return iterator
+
+      // Iterable<Number>
+      // Iterable<Bytes>
+      if (Number.isInteger(first.value) || isBytes(first.value)) {
+        yield toFileObject((function * () {
+          yield first.value
+          yield * iterator
+        })())
+        return
       }
+
+      // Iterable<Bloby>
+      // Iterable<String>
+      // Iterable<{ path, content }>
+      if (isFileObject(first.value) || isBloby(first.value) || typeof first.value === 'string') {
+        yield toFileObject(first.value)
+        for (const obj of iterator) {
+          yield toFileObject(obj)
+        }
+        return
+      }
+
+      throw errCode(new Error('Unexpected input: ' + typeof input), 'ERR_UNEXPECTED_INPUT')
     })()
   }
 
   // AsyncIterable<?>
   if (input[Symbol.asyncIterator]) {
-    return (async function * () { // eslint-disable-line require-await
-      for await (const chunk of input) {
-        yield toFileObject(chunk)
+    return (async function * () {
+      const iterator = input[Symbol.asyncIterator]()
+      const first = await iterator.next()
+      if (first.done) return iterator
+
+      // AsyncIterable<Bytes>
+      if (isBytes(first.value)) {
+        yield toFileObject((async function * () { // eslint-disable-line require-await
+          yield first.value
+          yield * iterator
+        })())
+        return
       }
+
+      // AsyncIterable<Bloby>
+      // AsyncIterable<String>
+      // AsyncIterable<{ path, content }>
+      if (isFileObject(first.value) || isBloby(first.value) || typeof first.value === 'string') {
+        yield toFileObject(first.value)
+        for await (const obj of iterator) {
+          yield toFileObject(obj)
+        }
+        return
+      }
+
+      throw errCode(new Error('Unexpected input: ' + typeof input), 'ERR_UNEXPECTED_INPUT')
+    })()
+  }
+
+  // { path, content: ? }
+  // Note: Detected _after_ AsyncIterable<?> because Node.js streams have a
+  // `path` property that passes this check.
+  if (isFileObject(input)) {
+    return (async function * () { // eslint-disable-line require-await
+      yield toFileObject(input)
+    })()
+  }
+
+  // PullStream<?>
+  if (typeof input === 'function') {
+    return (async function * () {
+      const iterator = pullStreamToIterable(input)[Symbol.asyncIterator]()
+      const first = await iterator.next()
+      if (first.done) return iterator
+
+      // PullStream<Bytes>
+      if (isBytes(first.value)) {
+        yield toFileObject((async function * () { // eslint-disable-line require-await
+          yield first.value
+          yield * iterator
+        })())
+        return
+      }
+
+      // PullStream<Bloby>
+      // PullStream<String>
+      // PullStream<{ path, content }>
+      if (isFileObject(first.value) || isBloby(first.value) || typeof first.value === 'string') {
+        yield toFileObject(first.value)
+        for await (const obj of iterator) {
+          yield toFileObject(obj)
+        }
+        return
+      }
+
+      throw errCode(new Error('Unexpected input: ' + typeof input), 'ERR_UNEXPECTED_INPUT')
     })()
   }
 
@@ -97,47 +187,60 @@ module.exports = function normaliseInput (input) {
 }
 
 function toFileObject (input) {
-  return {
-    path: input.path || '',
-    content: toAsyncIterable(input.content || input)
+  const obj = { path: input.path || '' }
+
+  if (input.content) {
+    obj.content = toAsyncIterable(input.content)
+  } else if (!input.path) { // Not already a file object with path or content prop
+    obj.content = toAsyncIterable(input)
   }
+
+  return obj
 }
 
 function toAsyncIterable (input) {
-  // Buffer|ArrayBuffer|TypedArray|array of bytes
-  if (isBytes(input)) {
+  // Bytes | String
+  if (isBytes(input) || typeof input === 'string') {
     return (async function * () { // eslint-disable-line require-await
       yield toBuffer(input)
     })()
   }
 
-  if (typeof input === 'string' || input instanceof String) {
-    return (async function * () { // eslint-disable-line require-await
-      yield toBuffer(input)
-    })()
-  }
-
-  // Blob|File
+  // Bloby
   if (isBloby(input)) {
     return blobToAsyncGenerator(input)
   }
 
   // Iterator<?>
   if (input[Symbol.iterator]) {
-    if (!isNaN(input[0])) {
-      return (async function * () { // eslint-disable-line require-await
-        yield toBuffer(input)
-      })()
-    }
-
     return (async function * () { // eslint-disable-line require-await
-      for (const chunk of input) {
-        yield toBuffer(chunk)
+      const iterator = input[Symbol.iterator]()
+      const first = iterator.next()
+      if (first.done) return iterator
+
+      // Iterable<Number>
+      if (Number.isInteger(first.value)) {
+        yield toBuffer(Array.from((function * () {
+          yield first.value
+          yield * iterator
+        })()))
+        return
       }
+
+      // Iterable<Bytes>
+      if (isBytes(first.value)) {
+        yield toBuffer(first.value)
+        for (const chunk of iterator) {
+          yield toBuffer(chunk)
+        }
+        return
+      }
+
+      throw errCode(new Error('Unexpected input: ' + typeof input), 'ERR_UNEXPECTED_INPUT')
     })()
   }
 
-  // AsyncIterable<?>
+  // AsyncIterable<Bytes>
   if (input[Symbol.asyncIterator]) {
     return (async function * () {
       for await (const chunk of input) {
@@ -146,23 +249,16 @@ function toAsyncIterable (input) {
     })()
   }
 
+  // PullStream<Bytes>
+  if (typeof input === 'function') {
+    return pullStreamToIterable(input)
+  }
+
   throw errCode(new Error(`Unexpected input: ${input}`, 'ERR_UNEXPECTED_INPUT'))
 }
 
 function toBuffer (chunk) {
-  if (isBytes(chunk)) {
-    return chunk
-  }
-
-  if (typeof chunk === 'string' || chunk instanceof String) {
-    return Buffer.from(chunk)
-  }
-
-  if (Array.isArray(chunk)) {
-    return Buffer.from(chunk)
-  }
-
-  throw new Error('Unexpected input: ' + typeof chunk)
+  return isBytes(chunk) ? chunk : Buffer.from(chunk)
 }
 
 function isBytes (obj) {

--- a/src/files/normalise-input.js
+++ b/src/files/normalise-input.js
@@ -3,6 +3,8 @@
 const errCode = require('err-code')
 const { Buffer } = require('buffer')
 const pullStreamToIterable = require('pull-stream-to-async-iterator')
+const { isSource } = require('is-pull-stream')
+const globalThis = require('../globalthis')
 
 /*
  * Transform one of:
@@ -153,7 +155,7 @@ module.exports = function normaliseInput (input) {
   }
 
   // PullStream<?>
-  if (typeof input === 'function') {
+  if (isSource(input)) {
     return (async function * () {
       const iterator = pullStreamToIterable(input)[Symbol.asyncIterator]()
       const first = await iterator.next()
@@ -250,7 +252,7 @@ function toAsyncIterable (input) {
   }
 
   // PullStream<Bytes>
-  if (typeof input === 'function') {
+  if (isSource(input)) {
     return pullStreamToIterable(input)
   }
 
@@ -266,7 +268,7 @@ function isBytes (obj) {
 }
 
 function isBloby (obj) {
-  return typeof Blob !== 'undefined' && obj instanceof global.Blob
+  return typeof globalThis.Blob !== 'undefined' && obj instanceof globalThis.Blob
 }
 
 // An object with a path or content property
@@ -300,7 +302,7 @@ async function * streamBlob (blob) {
 async function * readBlob (blob, options) {
   options = options || {}
 
-  const reader = new global.FileReader()
+  const reader = new globalThis.FileReader()
   const chunkSize = options.chunkSize || 1024 * 1024
   let offset = options.offset || 0
 

--- a/test/files/normalise-input.spec.js
+++ b/test/files/normalise-input.spec.js
@@ -1,0 +1,138 @@
+'use strict'
+
+/* eslint-env mocha */
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const normalise = require('../../src/files/normalise-input')
+const { supportsFileReader } = require('../../src/supports')
+const { Buffer } = require('buffer')
+const all = require('async-iterator-all')
+
+chai.use(dirtyChai)
+const expect = chai.expect
+
+const STRING = 'hello world'
+const BUFFER = Buffer.from(STRING)
+const ARRAY = Array.from(BUFFER)
+let BLOB
+
+if (supportsFileReader) {
+  BLOB = new global.Blob([
+    STRING
+  ])
+}
+
+async function verifyNormalisation (input) {
+  expect(input.length).to.equal(1)
+
+  if (!input[0].content[Symbol.asyncIterator] && !input[0].content[Symbol.iterator]) {
+    chai.assert.fail(`Content should have been an iterable or an async iterable`)
+  }
+
+  expect(await all(input[0].content)).to.deep.equal([BUFFER])
+  expect(input[0].path).to.equal('')
+}
+
+async function testContent (input) {
+  const result = await all(normalise(input))
+
+  await verifyNormalisation(result)
+}
+
+function iterableOf (thing) {
+  return [thing]
+}
+
+function asyncIterableOf (thing) {
+  return (async function * () { // eslint-disable-line require-await
+    yield thing
+  }())
+}
+
+describe('normalise-input', function () {
+  function testInputType (content, name) {
+    it(name, async function () {
+      await testContent(content)
+    })
+
+    it(`Iterable<${name}>`, async function () {
+      await testContent(iterableOf(content))
+    })
+
+    it(`AsyncIterable<${name}>`, async function () {
+      await testContent(asyncIterableOf(content))
+    })
+
+    if (name !== 'Blob') {
+      it(`AsyncIterable<Iterable<${name}>>`, async function () {
+        await testContent(asyncIterableOf(iterableOf(content)))
+      })
+
+      it(`AsyncIterable<AsyncIterable<${name}>>`, async function () {
+        await testContent(asyncIterableOf(asyncIterableOf(content)))
+      })
+    }
+
+    it(`{ path: '', content: ${name} }`, async function () {
+      await testContent({ path: '', content })
+    })
+
+    if (name !== 'Blob') {
+      it(`{ path: '', content: Iterable<${name}> }`, async function () {
+        await testContent({ path: '', content: iterableOf(content) })
+      })
+
+      it(`{ path: '', content: AsyncIterable<${name}> }`, async function () {
+        await testContent({ path: '', content: asyncIterableOf(content) })
+      })
+    }
+
+    it(`Iterable<{ path: '', content: ${name} }`, async function () {
+      await testContent(iterableOf({ path: '', content }))
+    })
+
+    if (name !== 'Blob') {
+      it(`Iterable<{ path: '', content: Iterable<${name}> }>`, async function () {
+        await testContent(iterableOf({ path: '', content: iterableOf(content) }))
+      })
+
+      it(`Iterable<{ path: '', content: AsyncIterable<${name}> }>`, async function () {
+        await testContent(iterableOf({ path: '', content: asyncIterableOf(content) }))
+      })
+    }
+
+    it(`AsyncIterable<{ path: '', content: ${name} }`, async function () {
+      await testContent(asyncIterableOf({ path: '', content }))
+    })
+
+    if (name !== 'Blob') {
+      it(`AsyncIterable<{ path: '', content: Iterable<${name}> }>`, async function () {
+        await testContent(asyncIterableOf({ path: '', content: iterableOf(content) }))
+      })
+
+      it(`AsyncIterable<{ path: '', content: AsyncIterable<${name}> }>`, async function () {
+        await testContent(asyncIterableOf({ path: '', content: asyncIterableOf(content) }))
+      })
+    }
+  }
+
+  describe('String', () => {
+    testInputType(STRING, 'String')
+  })
+
+  describe('Buffer', () => {
+    testInputType(BUFFER, 'Buffer')
+  })
+
+  describe('Blob', () => {
+    if (!supportsFileReader) {
+      return
+    }
+
+    testInputType(BLOB, 'Blob')
+  })
+
+  describe('Iterable<Number>', () => {
+    testInputType(ARRAY, 'Iterable<Number>')
+  })
+})

--- a/test/files/normalise-input.spec.js
+++ b/test/files/normalise-input.spec.js
@@ -8,6 +8,7 @@ const { supportsFileReader } = require('../../src/supports')
 const { Buffer } = require('buffer')
 const all = require('async-iterator-all')
 const pull = require('pull-stream')
+const globalThis = require('../../src/globalthis')
 
 chai.use(dirtyChai)
 const expect = chai.expect
@@ -19,7 +20,7 @@ const TYPEDARRAY = Uint8Array.from(ARRAY)
 let BLOB
 
 if (supportsFileReader) {
-  BLOB = new global.Blob([
+  BLOB = new globalThis.Blob([
     STRING
   ])
 }


### PR DESCRIPTION
This PR follows on from [this comment](https://github.com/ipfs/js-ipfs/pull/2379#discussion_r316549458) and allows an input normalisation function to be shared between ipfs and the http client.

All supported types are tested, at the moment they are (from the test output):

```
  normalise-input
    String
      ✓ String
      ✓ { path: '', content: String }
      ✓ Iterable<{ path: '', content: String }
      ✓ AsyncIterable<{ path: '', content: String }
      ✓ PullStream<{ path: '', content: String }
    Buffer
      ✓ Buffer
      ✓ Iterable<Buffer>
      ✓ AsyncIterable<Buffer>
      ✓ PullStream<Buffer>
      ✓ { path: '', content: Buffer }
      ✓ { path: '', content: Iterable<Buffer> }
      ✓ { path: '', content: AsyncIterable<Buffer> }
      ✓ { path: '', content: PullStream<Buffer> }
      ✓ Iterable<{ path: '', content: Buffer }
      ✓ AsyncIterable<{ path: '', content: Buffer }
      ✓ PullStream<{ path: '', content: Buffer }
      ✓ Iterable<{ path: '', content: Iterable<Buffer> }>
      ✓ Iterable<{ path: '', content: AsyncIterable<Buffer> }>
      ✓ AsyncIterable<{ path: '', content: Iterable<Buffer> }>
      ✓ AsyncIterable<{ path: '', content: AsyncIterable<Buffer> }>
      ✓ PullStream<{ path: '', content: PullStream<Buffer> }>
    Blob
      ✓ Blob
      ✓ { path: '', content: Blob }
      ✓ Iterable<{ path: '', content: Blob }
      ✓ AsyncIterable<{ path: '', content: Blob }
      ✓ PullStream<{ path: '', content: Blob }
    Iterable<Number>
      ✓ Iterable<Number>
      ✓ { path: '', content: Iterable<Number> }
      ✓ Iterable<{ path: '', content: Iterable<Number> }
      ✓ AsyncIterable<{ path: '', content: Iterable<Number> }
      ✓ PullStream<{ path: '', content: Iterable<Number> }
    TypedArray
      ✓ TypedArray
      ✓ Iterable<TypedArray>
      ✓ AsyncIterable<TypedArray>
      ✓ PullStream<TypedArray>
      ✓ { path: '', content: TypedArray }
      ✓ { path: '', content: Iterable<TypedArray> }
      ✓ { path: '', content: AsyncIterable<TypedArray> }
      ✓ { path: '', content: PullStream<TypedArray> }
      ✓ Iterable<{ path: '', content: TypedArray }
      ✓ AsyncIterable<{ path: '', content: TypedArray }
      ✓ PullStream<{ path: '', content: TypedArray }
      ✓ Iterable<{ path: '', content: Iterable<TypedArray> }>
      ✓ Iterable<{ path: '', content: AsyncIterable<TypedArray> }>
      ✓ AsyncIterable<{ path: '', content: Iterable<TypedArray> }>
      ✓ AsyncIterable<{ path: '', content: AsyncIterable<TypedArray> }>
      ✓ PullStream<{ path: '', content: PullStream<TypedArray> }>
```

Can you think of any others?  Could add tests for browser-centric typed arrays I guess?

Some notes:

* We will now support `ipfs.add`ing a bunch of new types for content such as strings, arrays full of numbers for a slightly more human-friendly API.
* I didn't include Pull Streams because in the brave new future the calling code should transform them before passing it to the core `ipfs.add`.
* I've tried to avoid `Buffer.from` unless its absolutely necessary because it involves copying buffers which is slow.
* Detecting `Iterable<Number>` involves [peeking at the iterable](https://github.com/ipfs/js-ipfs-utils/pull/5/files#diff-186d7179ac3708b245048fe3dc474652R127-R130) and is a little fragile as it assumes the iterable is full of the same type
* Maybe at some point in the future we should revisit this and convert everything to [BufferList](https://www.npmjs.com/package/bl)s to avoid the `Buffer.from` copy problem

I haven't integrated this with ipfs yet, just putting this up for early feedback.