### PR TITLE
feat: support blobs, file objects, iterators and async iterators

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "buffer": "^5.2.1",
+    "err-code": "^2.0.0",
+    "is-blob": "^2.0.1",
     "is-buffer": "^2.0.3",
     "is-electron": "^2.2.0",
     "is-pull-stream": "0.0.0",


### PR DESCRIPTION
This allows us to accept async iterators as arguments to ipfs.add and friends.

It also allows adding plain old js things like strings and arrays, so hooray for that.