### PR TITLE
feat: support pull streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "is-pull-stream": "0.0.0",
     "is-stream": "^2.0.0",
     "kind-of": "^6.0.2",
+    "pull-stream-to-async-iterator": "^1.0.2",
     "readable-stream": "^3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the `normaliseInput` function to accept pull streams.

I've also made the following changes:

1. Update the docs for supported inputs
    * `Buffer|ArrayBuffer|TypedArray` is aliased as `Bytes`
    * `Blob|File` is aliased as `Bloby`
    * Added info for what a input "means" i.e. causes single/multiple files to be added
1. Peek the first item of an (async) iterator properly
1. Move file object check below `input[Symbol.asyncIterator]` check because Node.js streams have a path property that will false positive the `isFileObject` check
1. Fix `toFileObject` to allow objects with no `content` property
1. Simplify `toBuffer` to remove checks that `Buffer.from` already does