### PR TITLE
feat: env/isTest

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -8,8 +8,10 @@ const IS_ELECTRON_RENDERER = IS_ELECTRON && IS_ENV_WITH_DOM
 const IS_NODE = typeof require === 'function' && typeof process !== 'undefined' && typeof process.release !== 'undefined' && process.release.name === 'node' && !IS_ELECTRON
 // eslint-disable-next-line no-undef
 const IS_WEBWORKER = typeof importScripts === 'function' && typeof self !== 'undefined' && typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope
+const IS_TEST = typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.NODE_ENV === 'test'
 
 module.exports = {
+  isTest: IS_TEST,
   isElectron: IS_ELECTRON,
   isElectronRenderer: IS_ELECTRON_RENDERER,
   isNode: IS_NODE,


### PR DESCRIPTION
> This PR unblocks https://github.com/ipfs/js-ipfs/pull/2304/#discussion_r321227711 

Adds `isTest` check to tell if runtime is part of tests: 

```js
process.env.NODE_ENV === 'test'
```

It does it in a way that works in browser  without `process.env` polyfills