### PR TITLE
feat: support old school streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "dirty-chai": "^2.0.1",
     "electron": "^6.0.6",
     "electron-mocha": "^8.0.3",
-    "pull-stream": "^3.6.13"
+    "pull-stream": "^3.6.13",
+    "readable-stream-2": "npm:readable-stream@^2.0.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/test/files/normalise-input.spec.js
+++ b/test/files/normalise-input.spec.js
@@ -8,6 +8,9 @@ const { supportsFileReader } = require('../../src/supports')
 const { Buffer } = require('buffer')
 const all = require('async-iterator-all')
 const pull = require('pull-stream')
+const Readable2 = require('readable-stream-2')
+const Readable3 = require('readable-stream')
+const ReadableNode = require('stream').Readable
 const globalThis = require('../../src/globalthis')
 
 chai.use(dirtyChai)
@@ -56,6 +59,42 @@ function pullStreamOf (thing) {
   return pull.values([thing])
 }
 
+function readable2Of (thing) {
+  const stream = new Readable2({
+    objectMode: true,
+    read () {
+      this.push(thing)
+      this.push(null)
+    }
+  })
+
+  return stream
+}
+
+function readable3Of (thing) {
+  const stream = new Readable3({
+    objectMode: true,
+    read () {
+      this.push(thing)
+      this.push(null)
+    }
+  })
+
+  return stream
+}
+
+function readableNodeOf (thing) {
+  const stream = new ReadableNode({
+    objectMode: true,
+    read () {
+      this.push(thing)
+      this.push(null)
+    }
+  })
+
+  return stream
+}
+
 describe('normalise-input', function () {
   function testInputType (content, name, isBytes) {
     it(name, async function () {
@@ -73,6 +112,18 @@ describe('normalise-input', function () {
 
       it(`PullStream<${name}>`, async function () {
         await testContent(pullStreamOf(content))
+      })
+
+      it(`Readable2<${name}>`, async function () {
+        await testContent(readable2Of(content))
+      })
+
+      it(`Readable3<${name}>`, async function () {
+        await testContent(readable3Of(content))
+      })
+
+      it(`ReadableNode<${name}>`, async function () {
+        await testContent(readableNodeOf(content))
       })
     }
 
@@ -92,6 +143,18 @@ describe('normalise-input', function () {
       it(`{ path: '', content: PullStream<${name}> }`, async function () {
         await testContent({ path: '', content: pullStreamOf(content) })
       })
+
+      it(`{ path: '', content: Readable2<${name}> }`, async function () {
+        await testContent({ path: '', content: readable2Of(content) })
+      })
+
+      it(`{ path: '', content: Readable3<${name}> }`, async function () {
+        await testContent({ path: '', content: readable3Of(content) })
+      })
+
+      it(`{ path: '', content: ReadableNode<${name}> }`, async function () {
+        await testContent({ path: '', content: readableNodeOf(content) })
+      })
     }
 
     it(`Iterable<{ path: '', content: ${name} }`, async function () {
@@ -104,6 +167,18 @@ describe('normalise-input', function () {
 
     it(`PullStream<{ path: '', content: ${name} }`, async function () {
       await testContent(pullStreamOf({ path: '', content }))
+    })
+
+    it(`Readable2<{ path: '', content: ${name} }`, async function () {
+      await testContent(readable2Of({ path: '', content }))
+    })
+
+    it(`Readable3<{ path: '', content: ${name} }`, async function () {
+      await testContent(readable3Of({ path: '', content }))
+    })
+
+    it(`ReadableNode<{ path: '', content: ${name} }`, async function () {
+      await testContent(readableNodeOf({ path: '', content }))
     })
 
     if (isBytes) {
@@ -125,6 +200,18 @@ describe('normalise-input', function () {
 
       it(`PullStream<{ path: '', content: PullStream<${name}> }>`, async function () {
         await testContent(pullStreamOf({ path: '', content: pullStreamOf(content) }))
+      })
+
+      it(`Readable2<{ path: '', content: Readable2<${name}> }>`, async function () {
+        await testContent(readable2Of({ path: '', content: readable2Of(content) }))
+      })
+
+      it(`Readable3<{ path: '', content: Readable3<${name}> }>`, async function () {
+        await testContent(readable3Of({ path: '', content: readable3Of(content) }))
+      })
+
+      it(`ReadableNode<{ path: '', content: Readable3<${name}> }>`, async function () {
+        await testContent(readableNodeOf({ path: '', content: readableNodeOf(content) }))
       })
     }
   }


### PR DESCRIPTION
In order not to break our users, this PR adds support for normalising instances the [`readable-stream`](https://www.npmjs.com/package/readable-stream) module @v2 and @v3 as input to `ipfs.add`.