### PR TITLE
fix: format mtime as timespec

### DIFF
--- a/src/files/format-mtime.js
+++ b/src/files/format-mtime.js
@@ -1,11 +1,16 @@
 'use strict'
 
 function formatMtime (mtime) {
-  if (mtime === undefined) {
-    return '-'
+  if (mtime == null) {
+    mtime = {
+      secs: 0,
+      nsecs: 0
+    }
   }
 
-  return new Date(mtime * 1000).toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale, {
+  const date = new Date((mtime.secs * 1000) + Math.round(mtime.nsecs / 1000))
+
+  return date.toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/src/files/format-mtime.js
+++ b/src/files/format-mtime.js
@@ -2,10 +2,7 @@
 
 function formatMtime (mtime) {
   if (mtime == null) {
-    mtime = {
-      secs: 0,
-      nsecs: 0
-    }
+    return '-'
   }
 
   const date = new Date((mtime.secs * 1000) + Math.round(mtime.nsecs / 1000))

--- a/test/files/format-mtime.spec.js
+++ b/test/files/format-mtime.spec.js
@@ -14,6 +14,6 @@ describe('format-mtime', function () {
   })
 
   it('formats empty mtime', function () {
-    expect(formatMtime()).to.include('Jan 1, 1970')
+    expect(formatMtime()).to.equal('-')
   })
 })

--- a/test/files/format-mtime.spec.js
+++ b/test/files/format-mtime.spec.js
@@ -10,10 +10,10 @@ const expect = chai.expect
 
 describe('format-mtime', function () {
   it('formats mtime', function () {
-    expect(formatMtime({ secs: 100, nsecs: 0 })).to.equal('Jan 1, 1970, 1:01:40 AM GMT+1')
+    expect(formatMtime({ secs: 100, nsecs: 0 })).to.include('Jan 1, 1970')
   })
 
   it('formats empty mtime', function () {
-    expect(formatMtime()).to.equal('Jan 1, 1970, 1:00:00 AM GMT+1')
+    expect(formatMtime()).to.include('Jan 1, 1970')
   })
 })

--- a/test/files/format-mtime.spec.js
+++ b/test/files/format-mtime.spec.js
@@ -10,6 +10,10 @@ const expect = chai.expect
 
 describe('format-mtime', function () {
   it('formats mtime', function () {
-    expect((new Date(formatMtime(0))).getTime()).to.equal(0)
+    expect(formatMtime({ secs: 100, nsecs: 0 })).to.equal('Jan 1, 1970, 1:01:40 AM GMT+1')
+  })
+
+  it('formats empty mtime', function () {
+    expect(formatMtime()).to.equal('Jan 1, 1970, 1:00:00 AM GMT+1')
   })
 })


### PR DESCRIPTION
Currently formats dates as `Jan 1, 1970, 1:00:00 AM GMT+1` - we may wish to revisit this later but we can do so in a subsequent PR.