### PR TITLE
fix: format mtime as timespec

### DIFF
--- a/src/files/format-mtime.js
+++ b/src/files/format-mtime.js
@@ -1,11 +1,13 @@
 'use strict'
 
 function formatMtime (mtime) {
-  if (mtime === undefined) {
+  if (mtime == null) {
     return '-'
   }
 
-  return new Date(mtime * 1000).toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale, {
+  const date = new Date((mtime.secs * 1000) + Math.round(mtime.nsecs / 1000))
+
+  return date.toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/test/files/format-mtime.spec.js
+++ b/test/files/format-mtime.spec.js
@@ -10,6 +10,10 @@ const expect = chai.expect
 
 describe('format-mtime', function () {
   it('formats mtime', function () {
-    expect((new Date(formatMtime(0))).getTime()).to.equal(0)
+    expect(formatMtime({ secs: 100, nsecs: 0 })).to.include('Jan 1, 1970')
+  })
+
+  it('formats empty mtime', function () {
+    expect(formatMtime()).to.equal('-')
   })
 })


### PR DESCRIPTION
Same changes as #19 but opened against master instead of the the `release/0.4.x` branch.