### PR TITLE
fix: downgrade to ky 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "^8.1.0",
     "is-electron": "^2.2.0",
     "it-glob": "0.0.7",
-    "ky": "^0.16.1",
+    "ky": "^0.15.0",
     "ky-universal": "^0.3.0",
     "stream-to-it": "^0.2.0"
   },


### PR DESCRIPTION
16 has https://github.com/sindresorhus/ky/issues/209

15 is also the version currently used by js-ipfs and js-ipfs-http-client