### PR TITLE
fix: avoid Identifier 'global' has already been declared

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -4,9 +4,8 @@
 const fetch = require('node-fetch')
 const merge = require('merge-options')
 const { URL, URLSearchParams } = require('iso-url')
-const global = require('./globalthis')
 const TextDecoder = require('./text-encoder')
-const Request = global.Request
+const Request = require('./globalthis').Request
 const AbortController = require('abort-controller')
 
 class TimeoutError extends Error {

--- a/src/text-encoder.browser.js
+++ b/src/text-encoder.browser.js
@@ -1,5 +1,3 @@
 'use strict'
 
-const global = require('./globalthis')
-
-module.exports = global.TextDecoder
+module.exports = require('./globalthis').TextDecoder


### PR DESCRIPTION
Closes https://github.com/ipfs/js-ipfs-utils/issues/29