### PR TITLE
fix: detect node stream with hasOwnProperty

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -263,7 +263,7 @@ const ndjson = async function * (source) {
 const streamToAsyncIterator = function (source) {
   if (isAsyncIterator(source)) {
     // Workaround for https://github.com/node-fetch/node-fetch/issues/766
-    if (source.hasOwnProperty('readable') && source.hasOwnProperty('writable')) {
+    if (Object.prototype.hasOwnProperty.call(source, 'readable') && Object.prototype.hasOwnProperty.call(source, 'writable')) {
       const iter = source[Symbol.asyncIterator]()
 
       const wrapper = {

--- a/src/http.js
+++ b/src/http.js
@@ -269,9 +269,7 @@ const streamToAsyncIterator = function (source) {
       const wrapper = {
         next: iter.next.bind(iter),
         return: () => {
-          if (source.writableEnded) {
-            source.destroy()
-          }
+          source.destroy()
 
           return iter.return()
         },

--- a/src/http.js
+++ b/src/http.js
@@ -263,7 +263,7 @@ const ndjson = async function * (source) {
 const streamToAsyncIterator = function (source) {
   if (isAsyncIterator(source)) {
     // Workaround for https://github.com/node-fetch/node-fetch/issues/766
-    if (source.writable && source.readable) {
+    if (source.hasOwnProperty('readable') && source.hasOwnProperty('writable')) {
       const iter = source[Symbol.asyncIterator]()
 
       const wrapper = {


### PR DESCRIPTION
Sometimes `.writable` is false due to a race condition so use `hasOwnProperty` instead.

Also destroys the stream when we are done with the iterator reguardless.