### PR TITLE
fix: simplify http client

### DIFF
--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -7,6 +7,7 @@ const toStream = require('it-to-stream')
 const delay = require('delay')
 const AbortController = require('abort-controller')
 const drain = require('it-drain')
+const all = require('it-all')
 const { isBrowser, isWebWorker } = require('../src/env')
 
 describe('http', function () {
@@ -25,6 +26,16 @@ describe('http', function () {
     controller.abort()
 
     await expect(res).to.eventually.be.rejectedWith(/aborted/)
+  })
+
+  it('parses the response as ndjson', async function () {
+    const res = await HTTP.post('http://localhost:3000', {
+      body: '{}\n{}'
+    })
+
+    const entities = await all(res.ndjson())
+
+    expect(entities).to.deep.equal([{}, {}])
   })
 
   it.skip('should handle errors in streaming bodies', async function () {


### PR DESCRIPTION
The conventions in the Fetch API is that you make a request, then do something with the response:

```javascript
const response = await fetch('...')
const data = await response.json()
```

It doesn't do things like:

```javascript
const data = await fetch.json('...') // what method would this use?
```

This PR brings our API more inline with Fetch so where we used to do:

```javascript
for await (const datum of http.ndjson('...')) { // what method does this use?

}
```

We now do the more idiomatic:

```javascript
const response = await http.post('...')

for await (const datum of response.ndjson()) {

}
```

It also removes the `.iterator` and `.stream` methods as they do not follow the Fetch pattern either though they can be added to the response object if they are useful.