### PR TITLE
feat: add iterator method to response

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "dirty-chai": "^2.0.1",
     "it-all": "^1.0.1",
     "it-drain": "^1.0.0",
+    "it-last": "^1.0.1",
     "it-to-stream": "^0.1.1"
   },
   "contributors": [

--- a/src/files/url-source.js
+++ b/src/files/url-source.js
@@ -5,9 +5,10 @@ const Http = require('../http')
 module.exports = async function * urlSource (url, options) {
   options = options || {}
   const http = new Http()
+  const response = await http.get(url)
 
   yield {
     path: decodeURIComponent(new URL(url).pathname.split('/').pop() || ''),
-    content: await http.iterator(url, { method: 'get' })
+    content: response.iterator()
   }
 }

--- a/src/http.js
+++ b/src/http.js
@@ -136,14 +136,14 @@ class HTTP {
       throw new HTTPError(response)
     }
 
-    response.iterator = async function * () {
+    response.iterator = function () {
       const it = streamToAsyncIterator(response.body)
 
       if (!isAsyncIterator(it)) {
         throw new Error('Can\'t convert fetch body into a Async Iterator:')
       }
 
-      yield * it
+      return it
     }
 
     response.ndjson = async function * () {

--- a/src/http.js
+++ b/src/http.js
@@ -136,14 +136,18 @@ class HTTP {
       throw new HTTPError(response)
     }
 
-    response.ndjson = async function * () {
+    response.iterator = async function * () {
       const it = streamToAsyncIterator(response.body)
 
       if (!isAsyncIterator(it)) {
         throw new Error('Can\'t convert fetch body into a Async Iterator:')
       }
 
-      for await (const chunk of ndjson(it)) {
+      yield * it
+    }
+
+    response.ndjson = async function * () {
+      for await (const chunk of ndjson(response.iterator())) {
         if (options.transform) {
           yield options.transform(chunk)
         } else {

--- a/test/files/url-source.spec.js
+++ b/test/files/url-source.spec.js
@@ -1,0 +1,18 @@
+'use strict'
+
+/* eslint-env mocha */
+
+const { expect } = require('../utils/chai')
+const all = require('it-all')
+const urlSource = require('../../src/files/url-source')
+const last = require('it-last')
+const { Buffer } = require('buffer')
+
+describe('url-source', function () {
+  it('can get url content', async function () {
+    const content = 'foo'
+    const file = await last(urlSource(`http://localhost:3000?body=${content}`))
+
+    await expect(all(file.content)).to.eventually.deep.equal([Buffer.from(content)])
+  })
+})

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -9,6 +9,7 @@ const AbortController = require('abort-controller')
 const drain = require('it-drain')
 const all = require('it-all')
 const { isBrowser, isWebWorker } = require('../src/env')
+const { Buffer } = require('buffer')
 
 describe('http', function () {
   it('makes a GET request', async function () {
@@ -36,6 +37,16 @@ describe('http', function () {
     const entities = await all(res.ndjson())
 
     expect(entities).to.deep.equal([{}, {}])
+  })
+
+  it('parses the response as an async iterable', async function () {
+    const res = await HTTP.post('http://localhost:3000', {
+      body: 'hello world'
+    })
+
+    const entities = await all(res.iterator())
+
+    expect(entities).to.deep.equal([Buffer.from('hello world')])
   })
 
   it.skip('should handle errors in streaming bodies', async function () {


### PR DESCRIPTION
Restores the previous `.iterator` method but on the response object similar to `.ndjson`:
    
```javascript
const response = await http.get('http://...')

for await (const buf of response.iterator()) {
  // buf is a Buffer
}
```

Also adds a test for urlSource because it turns out it uses `.iterator` but was untested.