### PR TITLE
feat: pass in Options Object to http Constructor

### DIFF
--- a/src/files/url-source.js
+++ b/src/files/url-source.js
@@ -3,9 +3,8 @@
 const Http = require('../http')
 
 module.exports = async function * urlSource (url, options) {
-  options = options || {}
   const http = new Http()
-  const response = await http.get(url)
+  const response = await http.get(url, options)
 
   yield {
     path: decodeURIComponent(new URL(url).pathname.split('/').pop() || ''),


### PR DESCRIPTION
It looks like the function was written to allow this as a parameter, but it was never used. This should allow for use cases like specifying custom headers while using `urlSource`. The `node-fetch` module falls back on [default options](https://github.com/node-fetch/node-fetch#options) if none are specified, so we shouldn't need to check and send an empty object at this step.