### PR TITLE
fix: make timeouts stricter

### DIFF
--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -24,6 +24,12 @@ describe('http', function () {
     expect(rsp).to.be.deep.eq({ test: 'one' })
   })
 
+  it('makes a GET request with a really short timeout', function () {
+    return expect(HTTP.get(`${process.env.ECHO_SERVER}/redirect?to=${encodeURI(`${process.env.ECHO_SERVER}/echo/query?test=one`)}`, {
+      timeout: 1
+    })).to.eventually.be.rejectedWith().instanceOf(HTTP.TimeoutError)
+  })
+
   it('makes a JSON request', async () => {
     const req = await HTTP.post(`${process.env.ECHO_SERVER}/echo`, {
       json: {


### PR DESCRIPTION
Sometimes a request can resolve before the timeout callback fires, this can be because the system is under load and the event loop is blocked.

This change looks at the time taken by a request to resolve when deciding if it's timed out as well as setting a regular js timeout to catch inactive requests.

It also removes the `timeout` option passed to `node-fetch` as it implements it's own timeout feature which results in two types of timeout error that can occur - ours and `node-fetch`'s.