### PR TITLE
Text encoder decoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "browser": {
     "fs-extra": false,
     "./src/text-encoder.js": "./src/text-encoder.browser.js",
+    "./src/text-decoder.js": "./src/text-decoder.browser.js",
     "./src/temp-dir.js": "./src/temp-dir.browser.js",
     "./src/path-join.js": "./src/path-join.browser.js"
   },

--- a/src/http.js
+++ b/src/http.js
@@ -4,7 +4,7 @@
 const fetch = require('node-fetch')
 const merge = require('merge-options').bind({ ignoreUndefined: true })
 const { URL, URLSearchParams } = require('iso-url')
-const TextDecoder = require('./text-encoder')
+const TextDecoder = require('./text-decoder')
 const AbortController = require('abort-controller')
 const anySignal = require('any-signal')
 

--- a/src/text-decoder.browser.js
+++ b/src/text-decoder.browser.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./globalthis').TextDecoder

--- a/src/text-decoder.js
+++ b/src/text-decoder.js
@@ -1,0 +1,2 @@
+'use strict'
+module.exports = require('util').TextDecoder

--- a/src/text-encoder.browser.js
+++ b/src/text-encoder.browser.js
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = require('./globalthis').TextDecoder
+module.exports = require('./globalthis').TextEncoder

--- a/src/text-encoder.js
+++ b/src/text-encoder.js
@@ -1,2 +1,2 @@
 'use strict'
-module.exports = require('util').TextDecoder
+module.exports = require('util').TextEncoder

--- a/test/text-codec.spec.js
+++ b/test/text-codec.spec.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/* eslint-env mocha */
+const { expect } = require('aegir/utils/chai')
+const TextEncoder = require('../src/text-encoder')
+const TextDecoder = require('../src/text-decoder')
+
+describe('text encode/decode', () => {
+  const data = Uint8Array.from([
+    104,
+    101,
+    108,
+    108,
+    111,
+    32,
+    119,
+    111,
+    114,
+    108,
+    100
+  ])
+
+  it('can encode text', () => {
+    const bytes = new TextEncoder().encode('hello world')
+    expect(bytes).to.be.deep.equal(data)
+  })
+
+  it('can decode text', () => {
+    const text = new TextDecoder().decode(data)
+    expect(text).to.be.equal('hello world')
+  })
+})


### PR DESCRIPTION
Context: @hugomrdias proposed to import `TextEncoder` from `text-encoder` which as it turns out exposes `TextDecoder` instead. 
https://github.com/ipfs/protons/pull/13#pullrequestreview-427374776

This change does following:

1. Adds text-decoder module to expose `TextDecoder`.
2. Changes text-encoder module to expose `TextEncoder`.
3. Adds a test that exercises both.

