### PR TITLE
feat: detect support for WebRTC data channels

### DIFF
--- a/src/supports.js
+++ b/src/supports.js
@@ -5,5 +5,6 @@ const globalThis = require('./globalthis')
 module.exports = {
   supportsFileReader: typeof self !== 'undefined' && 'FileReader' in self,
   supportsWebRTC: 'RTCPeerConnection' in globalThis &&
-  (typeof navigator !== 'undefined' && typeof navigator.mediaDevices !== 'undefined' && 'getUserMedia' in navigator.mediaDevices)
+  (typeof navigator !== 'undefined' && typeof navigator.mediaDevices !== 'undefined' && 'getUserMedia' in navigator.mediaDevices),
+  supportsWebRTCDataChannels: 'RTCPeerConnection' in globalThis
 }

--- a/test/supports.spec.js
+++ b/test/supports.spec.js
@@ -62,7 +62,7 @@ describe('supports', function () {
     }
   })
 
-  it('supportsWebRTC should return true in Web Worker', function () {
+  it('supportsWebRTC should return false in Web Worker', function () {
     if (env.isWebWorker) {
       expect(supports.supportsWebRTC).to.be.false()
     } else {
@@ -102,7 +102,7 @@ describe('supports', function () {
     }
   })
 
-  it('supportsWebRTCDataChannels should return true in Web Worker', function () {
+  it('supportsWebRTCDataChannels should return false in Web Worker', function () {
     if (env.isWebWorker) {
       expect(supports.supportsWebRTCDataChannels).to.be.false()
     } else {

--- a/test/supports.spec.js
+++ b/test/supports.spec.js
@@ -85,4 +85,44 @@ describe('supports', function () {
       this.skip()
     }
   })
+
+  it('supportsWebRTCDataChannels should return false in node', function () {
+    if (env.isNode) {
+      expect(supports.supportsWebRTCDataChannels).to.be.false()
+    } else {
+      this.skip()
+    }
+  })
+
+  it('supportsWebRTCDataChannels should return true in browser', function () {
+    if (env.isBrowser) {
+      expect(supports.supportsWebRTCDataChannels).to.be.true()
+    } else {
+      this.skip()
+    }
+  })
+
+  it('supportsWebRTCDataChannels should return true in Web Worker', function () {
+    if (env.isWebWorker) {
+      expect(supports.supportsWebRTCDataChannels).to.be.false()
+    } else {
+      this.skip()
+    }
+  })
+
+  it('supportsWebRTCDataChannels should return false in Electron main', function () {
+    if (env.isElectron && !env.isElectronRenderer) {
+      expect(supports.supportsWebRTCDataChannels).to.be.false()
+    } else {
+      this.skip()
+    }
+  })
+
+  it('supportsWebRTCDataChannels should return true in Electron renderer', function () {
+    if (env.isElectronRenderer) {
+      expect(supports.supportsWebRTCDataChannels).to.be.true()
+    } else {
+      this.skip()
+    }
+  })
 })


### PR DESCRIPTION
The use of WebRTC in IPFS is only as a data channel, we don't use getUserMedia and sometimes the user has restricted access to this API so add a 'supports' test that is just for data channels.

Fixes #50