### PR TITLE
fix: handle non-printable characters in browser responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "delay": "^4.3.0",
     "it-all": "^1.0.2",
     "it-drain": "^1.0.1",
-    "it-last": "^1.0.2"
+    "it-last": "^1.0.2",
+    "uint8arrays": "^1.1.0"
   },
   "contributors": [
     "Hugo Dias <hugomrdias@gmail.com>",

--- a/src/http/fetch.browser.js
+++ b/src/http/fetch.browser.js
@@ -50,6 +50,8 @@ const fetch = (url, options = {}) => {
     request.upload.onprogress = options.onUploadProgress
   }
 
+  request.responseType = 'arraybuffer'
+
   return new Promise((resolve, reject) => {
     /**
      * @param {Event} event

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -10,6 +10,8 @@ const drain = require('it-drain')
 const all = require('it-all')
 const { isBrowser, isWebWorker } = require('../src/env')
 const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayEquals = require('uint8arrays/equals')
 
 describe('http', function () {
   it('makes a GET request', async function () {
@@ -174,5 +176,14 @@ describe('http', function () {
 
     expect(upload).to.be.greaterThan(0)
     expect(download).to.be.greaterThan(0)
+  })
+
+  it('makes a GET request with unprintable characters', async function () {
+    const buf = uint8ArrayFromString('a163666f6f6c6461672d63626f722d626172', 'base16')
+    const params = Array.from(buf).map(val => `data=${val.toString()}`).join('&')
+
+    const req = await HTTP.get(`${process.env.ECHO_SERVER}/download?${params}`)
+    const rsp = await req.arrayBuffer()
+    expect(uint8ArrayEquals(new Uint8Array(rsp), buf)).to.be.true()
   })
 })


### PR DESCRIPTION
Fixes a regression introduced by #54 - in the browser by default the response body is interpreted as a string which can become corrupted when non-printable characters are encountered.

Setting the responseType param to `arraybuffer` makes it behave in a similar way to node.

This is currently manifesting itself as a browser test failure for ipfs as the DAG node is retrieved from the server with garbage characters in the block:

```
ipfs-http-client: FAILED TESTS:
ipfs-http-client:   .dag
ipfs-http-client:     ✖ should be able to put and get a DAG node with format dag-cbor
ipfs-http-client:       Chrome Headless 84.0.4147.125 (Linux x86_64)
ipfs-http-client:     Error: Undeterminated nesting
ipfs-http-client:         at Decoder._decode (file:/home/travis/build/ipfs/js-ipfs/node_modules/borc/src/decoder.js:603:15)
ipfs-http-client:         at Decoder.decodeAll (file:/home/travis/build/ipfs/js-ipfs/node_modules/borc/src/decoder.js:624:10)
ipfs-http-client:         at Object.exports.deserialize (file:/home/travis/build/ipfs/js-ipfs/node_modules/ipld-dag-cbor/src/util.js:169:23)
ipfs-http-client:         at Object.exports.resolve (file:/home/travis/build/ipfs/js-ipfs/node_modules/ipld-dag-cbor/src/resolver.js:27:19)
ipfs-http-client:         at Object.eval [as get] (file:/home/travis/build/ipfs/js-ipfs/packages/ipfs-http-client/src/dag/get.js:36:24)
ipfs-http-client:         at async Context.eval (file:/home/travis/build/ipfs/js-ipfs/packages/ipfs-http-client/test/dag.spec.js:58:20)
```