### PR TITLE
chore: revert to upstream electron-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "./src/temp-dir.js": "./src/temp-dir.browser.js",
     "./src/path-join.js": "./src/path-join.browser.js",
     "./test/files/glob-source.spec.js": false,
-    "@achingbrain/electron-fetch": false
+    "electron-fetch": false
   },
   "repository": "github:ipfs/js-ipfs-utils",
   "scripts": {
@@ -35,7 +35,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@achingbrain/electron-fetch": "^1.7.2",
+    "electron-fetch": "arantes555/electron-fetch#fix-abort-request",
     "abort-controller": "^3.0.0",
     "any-signal": "^2.1.0",
     "buffer": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "electron-fetch": "arantes555/electron-fetch#fix-abort-request",
+    "electron-fetch": "^1.7.2",
     "abort-controller": "^3.0.0",
     "any-signal": "^2.1.0",
     "buffer": "^6.0.1",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,7 +3,7 @@
 const { isElectronMain } = require('./env')
 
 if (isElectronMain) {
-  module.exports = require('electron-fetch')
+  module.exports = require('electron-fetch/src/index')
 } else {
   // use window.fetch if it is available, fall back to node-fetch if not
   module.exports = require('native-fetch')

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,7 +3,7 @@
 const { isElectronMain } = require('./env')
 
 if (isElectronMain) {
-  module.exports = require('electron-fetch/src/index')
+  module.exports = require('electron-fetch')
 } else {
   // use window.fetch if it is available, fall back to node-fetch if not
   module.exports = require('native-fetch')

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,7 +3,7 @@
 const { isElectronMain } = require('./env')
 
 if (isElectronMain) {
-  module.exports = require('@achingbrain/electron-fetch')
+  module.exports = require('electron-fetch')
 } else {
   // use window.fetch if it is available, fall back to node-fetch if not
   module.exports = require('native-fetch')


### PR DESCRIPTION
No need to use the fork any more as the original bug has been [fixed](https://github.com/arantes555/electron-fetch/pull/31).

The js-IPFS build passes with this change: https://github.com/ipfs/js-ipfs/pull/3414