### PR TITLE
chore: update native-abort-controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "it-to-stream": "^0.1.2",
     "merge-options": "^3.0.4",
     "nanoid": "^3.1.20",
-    "native-abort-controller": "^1.0.0",
+    "native-abort-controller": "^1.0.3",
     "native-fetch": "2.0.1",
     "node-fetch": "^2.6.1",
     "stream-to-it": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "it-to-stream": "^0.1.2",
     "merge-options": "^3.0.4",
     "nanoid": "^3.1.20",
-    "native-abort-controller": "0.0.3",
+    "native-abort-controller": "^1.0.0",
     "native-fetch": "2.0.1",
     "node-fetch": "^2.6.1",
     "stream-to-it": "^0.2.2",

--- a/src/http.js
+++ b/src/http.js
@@ -6,7 +6,7 @@ const { TimeoutError, HTTPError } = require('./http/error')
 const merge = require('merge-options').bind({ ignoreUndefined: true })
 const { URL, URLSearchParams } = require('iso-url')
 const TextDecoder = require('./text-decoder')
-const AbortController = require('native-abort-controller')
+const { AbortController } = require('native-abort-controller')
 const anySignal = require('any-signal')
 
 /**

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -6,7 +6,7 @@ const HTTP = require('../src/http')
 // @ts-ignore
 const toStream = require('it-to-stream')
 const delay = require('delay')
-const AbortController = require('native-abort-controller')
+const { AbortController } = require('native-abort-controller')
 const drain = require('it-drain')
 const all = require('it-all')
 const { isBrowser, isWebWorker } = require('../src/env')

--- a/types/native-abort-controller/index.d.ts
+++ b/types/native-abort-controller/index.d.ts
@@ -1,4 +1,0 @@
-export type { AbortController, AbortSignal }
-
-export default AbortController
-export = AbortController


### PR DESCRIPTION
To avoid extending built-in classes you now need to use named exports when importing `native-abort-controller`.