### PR TITLE
fix: url.search is a string so do not set it as a URLSearchParams

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -111,11 +111,11 @@ class HTTP {
 
     if (searchParams) {
       if (typeof transformSearchParams === 'function') {
-        // @ts-ignore
         url.search = transformSearchParams(new URLSearchParams(opts.searchParams))
+      } else if (searchParams instanceof URLSearchParams) {
+        url.search = searchParams.toString()
       } else {
-        // @ts-ignore
-        url.search = new URLSearchParams(opts.searchParams)
+        url.search = new URLSearchParams(searchParams).toString()
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface HTTPOptions extends FetchOptions {
   /**
    * Transform search params
    */
-  transformSearchParams?: (params: URLSearchParams) => URLSearchParams
+  transformSearchParams?: (params: URLSearchParams) => string
   /**
    * When iterating the response body, transform each chunk with this function.
    */

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -182,4 +182,23 @@ describe('http', function () {
     const rsp = await req.arrayBuffer()
     expect(uint8ArrayEquals(new Uint8Array(rsp), buf)).to.be.true()
   })
+
+  it('allows transforming search params', async function () {
+    const res = await HTTP.post('echo/query', {
+      base: ECHO_SERVER,
+      body: 'hello world',
+      searchParams: new URLSearchParams({
+        foo: 'bar'
+      }),
+      transformSearchParams: (params) => {
+        expect(params.get('foo')).to.equal('bar')
+
+        return 'baz=qux'
+      }
+    })
+
+    const query = JSON.parse(await res.text())
+
+    expect(query).to.have.property('baz', 'qux')
+  })
 })


### PR DESCRIPTION
Updates the types to make transformSearchParams return a string and adds a test.