### PR TITLE
fix: allow all supported unixfs time types

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/fs-extra": "^9.0.5",
     "aegir": "^30.3.0",
     "delay": "^5.0.0",
+    "ipfs-unixfs": "^4.0.1",
     "it-all": "^1.0.4",
     "it-drain": "^1.0.3",
     "it-last": "^1.0.4",

--- a/src/files/glob-source.js
+++ b/src/files/glob-source.js
@@ -17,7 +17,7 @@ const errCode = require('err-code')
  * @param {boolean} [options.preserveMode] - preserve mode
  * @param {boolean} [options.preserveMtime] - preserve mtime
  * @param {number} [options.mode] - mode to use - if preserveMode is true this will be ignored
- * @param {Date} [options.mtime] - mtime to use - if preserveMtime is true this will be ignored
+ * @param {import('ipfs-unixfs').MtimeLike} [options.mtime] - mtime to use - if preserveMtime is true this will be ignored
  * @yields {Object} File objects in the form `{ path: String, content: AsyncIterator<Buffer> }`
  */
 module.exports = async function * globSource (paths, options) {

--- a/test/files/glob-source.spec.js
+++ b/test/files/glob-source.spec.js
@@ -233,4 +233,40 @@ describe('glob-source', () => {
     expect(result).to.have.nested.property('[5].path', '/dir/nested-dir/other.txt')
     expect(result).to.have.deep.nested.property('[5].mtime', new Date(5))
   })
+
+  it('overrides mtime for file with secs/nsecs', async function () {
+    if (!isNode) {
+      return this.skip()
+    }
+
+    const result = await all(globSource(fixture('/dir/file-1.txt'), {
+      mtime: { secs: 5, nsecs: 0 }
+    }))
+
+    expect(result).to.have.deep.nested.property('[0].mtime', { secs: 5, nsecs: 0 })
+  })
+
+  it('overrides mtime for file with hrtime', async function () {
+    if (!isNode) {
+      return this.skip()
+    }
+
+    const result = await all(globSource(fixture('/dir/file-1.txt'), {
+      mtime: [5, 0]
+    }))
+
+    expect(result).to.have.deep.nested.property('[0].mtime', [5, 0])
+  })
+
+  it('overrides mtime for file with UnixFS timespec', async function () {
+    if (!isNode) {
+      return this.skip()
+    }
+
+    const result = await all(globSource(fixture('/dir/file-1.txt'), {
+      mtime: { Seconds: 5, FractionalNanoseconds: 0 }
+    }))
+
+    expect(result).to.have.deep.nested.property('[0].mtime', { Seconds: 5, FractionalNanoseconds: 0 })
+  })
 })


### PR DESCRIPTION
Date is not fine grained enough - nanoseconds are ignored so expand
the supported types of time representation allowed.