### PR TITLE
fix: do not use electron-fetch types

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "./src/temp-dir.js": "./src/temp-dir.browser.js",
     "./src/path-join.js": "./src/path-join.browser.js",
     "./test/files/glob-source.spec.js": false,
-    "electron-fetch": false
+    "electron-fetch": false,
+    "fs-extra": false,
+    "graceful-fs": false
   },
   "types": "dist/src/index.d.ts",
   "typesVersions": {
@@ -63,13 +65,16 @@
   "devDependencies": {
     "@types/err-code": "^2.0.0",
     "@types/fs-extra": "^9.0.5",
-    "aegir": "^30.3.0",
+    "aegir": "^32.2.0",
     "delay": "^5.0.0",
+    "events": "^3.3.0",
     "ipfs-unixfs": "^4.0.1",
     "it-all": "^1.0.4",
     "it-drain": "^1.0.3",
     "it-last": "^1.0.4",
-    "uint8arrays": "^2.0.5"
+    "readable-stream": "^3.6.0",
+    "uint8arrays": "^2.0.5",
+    "util": "^0.12.3"
   },
   "eslintConfig": {
     "extends": "ipfs",

--- a/src/http.js
+++ b/src/http.js
@@ -10,7 +10,7 @@ const { AbortController } = require('native-abort-controller')
 const anySignal = require('any-signal')
 
 /**
- * @typedef {import('electron-fetch').Response} Response
+ * @typedef {import('native-fetch').Response} Response
  * @typedef {import('stream').Readable} NodeReadableStream
  * @typedef {import('stream').Duplex} NodeDuplexStream
  * @typedef {import('./types').HTTPOptions} HTTPOptions

--- a/src/http/error.js
+++ b/src/http/error.js
@@ -18,7 +18,7 @@ exports.AbortError = AbortError
 
 class HTTPError extends Error {
   /**
-   * @param {import('electron-fetch').Response} response
+   * @param {import('native-fetch').Response} response
    */
   constructor (response) {
     super(response.statusText)

--- a/src/http/fetch.node.js
+++ b/src/http/fetch.node.js
@@ -5,7 +5,7 @@ const { Request, Response, Headers, default: nativeFetch } = require('../fetch')
 const toStream = require('it-to-stream')
 const { Buffer } = require('buffer')
 /**
- * @typedef {import('electron-fetch').BodyInit} BodyInit
+ * @typedef {import('native-fetch').BodyInit} BodyInit
  * @typedef {import('stream').Readable} NodeReadableStream
  *
  * @typedef {import('../types').FetchOptions} FetchOptions

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-import type { RequestInit, Response } from 'electron-fetch'
+import type { RequestInit, Response } from 'native-fetch'
 interface ProgressStatus {
   total: number
   loaded: number

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-import type { RequestInit, Response } from 'native-fetch'
+import type { RequestInit, Response } from '../types/native-fetch'
 interface ProgressStatus {
   total: number
   loaded: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface HTTPOptions extends FetchOptions {
   /**
    * The base URL to use in case url is a relative URL
    */
-  base? : string
+  base?: string
   /**
    * Throw not ok responses as Errors
    */


### PR DESCRIPTION
Use our imaginary native-fetch types instead as they do not require
consuming modules to also depend on electron-fetch.