### PR TITLE
chore: remove web-encoding in a backwards compatible way

### DIFF
--- a/src/text-decoder.js
+++ b/src/text-decoder.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = TextDecoder

--- a/src/text-encoder.js
+++ b/src/text-encoder.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = TextEncoder

--- a/test/text-codec.spec.js
+++ b/test/text-codec.spec.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/* eslint-env mocha */
+const { expect } = require('aegir/utils/chai')
+const TextEncoder = require('../src/text-encoder')
+const TextDecoder = require('../src/text-decoder')
+
+describe('text encode/decode', () => {
+  const data = Uint8Array.from([
+    104,
+    101,
+    108,
+    108,
+    111,
+    32,
+    119,
+    111,
+    114,
+    108,
+    100
+  ])
+
+  it('can encode text', () => {
+    const bytes = new TextEncoder().encode('hello world')
+    expect(bytes).to.be.deep.equal(data)
+  })
+
+  it('can decode text', () => {
+    const text = new TextDecoder().decode(data)
+    expect(text).to.be.equal('hello world')
+  })
+})


### PR DESCRIPTION
Datastores in the wild use these functions so remove web-encoding without breaking the public api.