### PR TITLE
fix: exclude glob-source.js in browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "./src/http/fetch.js": "./src/http/fetch.browser.js",
     "./src/temp-dir.js": "./src/temp-dir.browser.js",
     "./src/path-join.js": "./src/path-join.browser.js",
+    "./src/files/glob-source": false,
     "./test/files/glob-source.spec.js": false,
     "electron-fetch": false,
     "fs-extra": false,


### PR DESCRIPTION
Fixes this issue: https://github.com/ipfs/js-ipfs/issues/3557

Related PR in `js-ipfs`: https://github.com/ipfs/js-ipfs/pull/3630