### PR TITLE
chore: remove fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "./src/files/glob-source": false,
     "./test/files/glob-source.spec.js": false,
     "electron-fetch": false,
-    "graceful-fs": false
+    "fs": false
   },
   "types": "dist/src/index.d.ts",
   "typesVersions": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "./src/files/glob-source": false,
     "./test/files/glob-source.spec.js": false,
     "electron-fetch": false,
-    "fs-extra": false,
     "graceful-fs": false
   },
   "types": "dist/src/index.d.ts",
@@ -50,7 +49,6 @@
     "buffer": "^6.0.1",
     "electron-fetch": "^1.7.2",
     "err-code": "^3.0.1",
-    "fs-extra": "^9.0.1",
     "is-electron": "^2.2.0",
     "iso-url": "^1.0.0",
     "it-glob": "~0.0.11",
@@ -63,8 +61,6 @@
     "stream-to-it": "^0.2.2"
   },
   "devDependencies": {
-    "@types/err-code": "^2.0.0",
-    "@types/fs-extra": "^9.0.5",
     "aegir": "^33.1.0",
     "delay": "^5.0.0",
     "events": "^3.3.0",

--- a/src/files/glob-source.js
+++ b/src/files/glob-source.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const fs = require('fs-extra')
+const fsp = require('fs').promises
+const fs = require('fs')
 const glob = require('it-glob')
 const Path = require('path')
 const errCode = require('err-code')
@@ -47,7 +48,7 @@ module.exports = async function * globSource (paths, options) {
     }
 
     const absolutePath = Path.resolve(process.cwd(), path)
-    const stat = await fs.stat(absolutePath)
+    const stat = await fsp.stat(absolutePath)
     const prefix = Path.dirname(absolutePath)
 
     let mode = options.mode
@@ -117,7 +118,7 @@ async function * toGlobSource ({ path, type, prefix, mode, mtime, preserveMode, 
   })
 
   for await (const p of glob(path, '**/*', globOptions)) {
-    const stat = await fs.stat(p)
+    const stat = await fsp.stat(p)
 
     if (preserveMode || preserveMtime) {
       if (preserveMode) {

--- a/test/files/glob-source.spec.js
+++ b/test/files/glob-source.spec.js
@@ -8,7 +8,7 @@ const path = require('path')
 const {
   isNode
 } = require('../../src/env')
-const fs = require('fs-extra')
+const fs = require('fs')
 
 /**
  * @param {string} file


### PR DESCRIPTION
The fs module has promises support so just use that instead.