### PR TITLE
fix: use node-fetch fork with fix for stream closed prematurely bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nanoid": "^3.1.20",
     "native-abort-controller": "^1.0.3",
     "native-fetch": "^3.0.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "npm:@achingbrain/node-fetch",
     "react-native-fetch-api": "^1.0.2",
     "stream-to-it": "^0.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nanoid": "^3.1.20",
     "native-abort-controller": "^1.0.3",
     "native-fetch": "^3.0.0",
-    "node-fetch": "npm:@achingbrain/node-fetch@^2.0.0",
+    "node-fetch": "npm:@achingbrain/node-fetch@^2.6.3",
     "react-native-fetch-api": "^1.0.2",
     "stream-to-it": "^0.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nanoid": "^3.1.20",
     "native-abort-controller": "^1.0.3",
     "native-fetch": "^3.0.0",
-    "node-fetch": "npm:@achingbrain/node-fetch",
+    "node-fetch": "npm:@achingbrain/node-fetch@^2.0.0",
     "react-native-fetch-api": "^1.0.2",
     "stream-to-it": "^0.2.2"
   },


### PR DESCRIPTION
https://github.com/node-fetch/node-fetch/pull/1064 fixes a bug in node-fetch to make it handle situations where the stream closes prematurely but it's been merged into the v3 release tree which is still future tech with no release date.

https://github.com/node-fetch/node-fetch/pull/1172 backports that fix to v2 but although approved it's not been merged and released yet so here we use a temporary fork published with that PR merged in.