### PR TITLE
fix: request body type

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,5 @@
+import { Readable as NodeReadableStream } from 'stream'
+
 interface ProgressStatus {
   total: number
   loaded: number
@@ -6,7 +8,9 @@ interface ProgressStatus {
 
 export interface ProgressFn { (status: ProgressStatus): void }
 
-export interface FetchOptions extends RequestInit {
+type Modify<T, R> = Omit<T, keyof R> & R
+
+export type FetchOptions = Modify<RequestInit, {
   /**
    * Extended body with support for node readable stream
    */
@@ -29,7 +33,7 @@ export interface FetchOptions extends RequestInit {
    */
   onDownloadProgress?: ProgressFn
   overrideMimeType?: string
-}
+}>
 
 export interface HTTPOptions extends FetchOptions {
   json?: any

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,9 +8,9 @@ interface ProgressStatus {
 
 export interface ProgressFn { (status: ProgressStatus): void }
 
-type Modify<T, R> = Omit<T, keyof R> & R
+type Override<T, R> = Omit<T, keyof R> & R
 
-export type FetchOptions = Modify<RequestInit, {
+export type FetchOptions = Override<RequestInit, {
   /**
    * Extended body with support for node readable stream
    */


### PR DESCRIPTION
Fixes two problems:

1. The import for `NodeReadableStream` was missing
2. We can't use `NodeReadableStream` as the type for `body` because it it not assignable to any type that makes up `BodyInit` so instead [modify](https://stackoverflow.com/questions/41285211/overriding-interface-property-type-defined-in-typescript-d-ts-file) the RequestInit type to omit the original `body` type and include the new one.

Fixes this error:

```
node_modules/ipfs-utils/dist/src/types.d.ts:11:18 - error TS2430: Interface 'FetchOptions' incorrectly extends interface 'RequestInit'.
  Types of property 'body' are incompatible.
    Type 'Readable | BodyInit | null | undefined' is not assignable to type 'BodyInit | null | undefined'.
      Type 'Readable' is not assignable to type 'BodyInit | null | undefined'.
        Type 'Readable' is missing the following properties from type 'ReadableStream<Uint8Array>': locked, cancel, getReader, pipeThrough, and 2 more.

11 export interface FetchOptions extends RequestInit {
                    ~~~~~~~~~~~~


Found 1 error.
```