### PR TITLE
fix: remove abort controller deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,11 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [16]
+        node: [14, 16]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
@@ -44,10 +44,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
+      - uses: actions/checkout@2
       - run: npm install
       - run: npx aegir test -t browser -t webworker --bail
   test-firefox:
@@ -55,9 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
       - run: npm install
       - run: npx aegir test -t browser -t webworker --bail -- --browsers FirefoxHeadless
   test-electron-main:
@@ -65,9 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
       - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-main --bail
   test-electron-renderer:
@@ -75,9 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
       - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-renderer --bail
   test-react-native-android:
@@ -85,10 +73,7 @@ jobs:
     needs: check
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
+      - uses: actions/checkout@2
       - run: npm install
       - uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -103,9 +88,6 @@ jobs:
   #   runs-on: macos-latest
   #   steps:
   #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 16
   #     - run: npm install
   #     - name: Create and run iOS simulator
   #       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,11 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [14, 16]
+        node: [16]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
@@ -45,6 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
       - run: npx aegir test -t browser -t webworker --bail
   test-firefox:
@@ -52,6 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
       - run: npx aegir test -t browser -t webworker --bail -- --browsers FirefoxHeadless
   test-electron-main:
@@ -59,6 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-main --bail
   test-electron-renderer:
@@ -66,6 +75,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-renderer --bail
   test-react-native-android:
@@ -74,6 +86,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm install
       - uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -88,6 +103,9 @@ jobs:
   #   runs-on: macos-latest
   #   steps:
   #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 16
   #     - run: npm install
   #     - name: Create and run iOS simulator
   #       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@2
+      - uses: actions/checkout@v2
       - run: npm install
       - run: npx aegir test -t browser -t webworker --bail
   test-firefox:
@@ -73,7 +73,7 @@ jobs:
     needs: check
     continue-on-error: true
     steps:
-      - uses: actions/checkout@2
+      - uses: actions/checkout@v2
       - run: npm install
       - uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "any-signal": "^2.1.0",
+    "any-signal": "^3.0.0",
     "buffer": "^6.0.1",
     "electron-fetch": "^1.7.2",
     "err-code": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "any-signal": "^2.1.0",
     "buffer": "^6.0.1",
     "electron-fetch": "^1.7.2",
@@ -60,7 +59,6 @@
     "it-to-stream": "^1.0.0",
     "merge-options": "^3.0.4",
     "nanoid": "^3.1.20",
-    "native-abort-controller": "^1.0.3",
     "native-fetch": "^3.0.0",
     "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
     "react-native-fetch-api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "stream-to-it": "^0.2.2"
   },
   "devDependencies": {
-    "aegir": "^35.0.1",
+    "aegir": "^36.1.1",
     "delay": "^5.0.0",
     "events": "^3.3.0",
     "ipfs-unixfs": "^6.0.4",

--- a/src/http.js
+++ b/src/http.js
@@ -5,7 +5,6 @@ const { fetch, Request, Headers } = require('./http/fetch')
 const { TimeoutError, HTTPError } = require('./http/error')
 const merge = require('merge-options').bind({ ignoreUndefined: true })
 const { URL, URLSearchParams } = require('iso-url')
-const { AbortController } = require('native-abort-controller')
 const anySignal = require('any-signal')
 
 /**

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -6,7 +6,6 @@ const HTTP = require('../src/http')
 // @ts-ignore
 const toStream = require('it-to-stream')
 const delay = require('delay')
-const { AbortController } = require('native-abort-controller')
 const drain = require('it-drain')
 const all = require('it-all')
 const { isBrowser, isWebWorker, isReactNative } = require('../src/env')


### PR DESCRIPTION
`AbortController` and `AbortSignal` are supported in browsers and node 14+ so the extra deps aren't necessary any more.