### PR TITLE
fix: swap @yields for @returns

### DIFF
--- a/src/files/glob-source.js
+++ b/src/files/glob-source.js
@@ -18,12 +18,12 @@ const errCode = require('err-code')
  * @param {boolean} [options.preserveMtime] - preserve mtime
  * @param {number} [options.mode] - mode to use - if preserveMode is true this will be ignored
  * @param {import('ipfs-unixfs').MtimeLike} [options.mtime] - mtime to use - if preserveMtime is true this will be ignored
- * @return {AsyncGenerator<{
+ * @return {AsyncIterable<{
  *   path: string;
  *   content: AsyncIterable<Buffer> | undefined;
  *   mode: number | undefined;
  *   mtime: import("ipfs-unixfs/types/src/types").MtimeLike | undefined;
- * }, void, unknown>} File objects that match glob
+ * }>} File objects that match glob
  */
 module.exports = async function * globSource (cwd, pattern, options) {
   options = options || {}

--- a/src/files/glob-source.js
+++ b/src/files/glob-source.js
@@ -18,12 +18,12 @@ const errCode = require('err-code')
  * @param {boolean} [options.preserveMtime] - preserve mtime
  * @param {number} [options.mode] - mode to use - if preserveMode is true this will be ignored
  * @param {import('ipfs-unixfs').MtimeLike} [options.mtime] - mtime to use - if preserveMtime is true this will be ignored
- * @return {AsyncIterable<{
+ * @return {AsyncGenerator<{
  *   path: string;
  *   content: AsyncIterable<Buffer> | undefined;
  *   mode: number | undefined;
  *   mtime: import("ipfs-unixfs/types/src/types").MtimeLike | undefined;
- * }>} File objects that match glob
+ * }, void, unknown>} File objects that match glob
  */
 module.exports = async function * globSource (cwd, pattern, options) {
   options = options || {}

--- a/src/files/glob-source.js
+++ b/src/files/glob-source.js
@@ -18,7 +18,12 @@ const errCode = require('err-code')
  * @param {boolean} [options.preserveMtime] - preserve mtime
  * @param {number} [options.mode] - mode to use - if preserveMode is true this will be ignored
  * @param {import('ipfs-unixfs').MtimeLike} [options.mtime] - mtime to use - if preserveMtime is true this will be ignored
- * @yields {Object} File objects in the form `{ path: String, content: AsyncIterator<Buffer> }`
+ * @return {AsyncGenerator<{
+ *   path: string;
+ *   content: AsyncIterable<Buffer> | undefined;
+ *   mode: number | undefined;
+ *   mtime: import("ipfs-unixfs/types/src/types").MtimeLike | undefined;
+ * }, void, unknown>} File objects that match glob
  */
 module.exports = async function * globSource (cwd, pattern, options) {
   options = options || {}

--- a/src/files/glob-source.js
+++ b/src/files/glob-source.js
@@ -18,11 +18,11 @@ const errCode = require('err-code')
  * @param {boolean} [options.preserveMtime] - preserve mtime
  * @param {number} [options.mode] - mode to use - if preserveMode is true this will be ignored
  * @param {import('ipfs-unixfs').MtimeLike} [options.mtime] - mtime to use - if preserveMtime is true this will be ignored
- * @return {AsyncGenerator<{
- *   path: string;
- *   content: AsyncIterable<Buffer> | undefined;
- *   mode: number | undefined;
- *   mtime: import("ipfs-unixfs/types/src/types").MtimeLike | undefined;
+ * @returns {AsyncGenerator<{
+ * path: string;
+ * content: AsyncIterable<Buffer> | undefined;
+ * mode: number | undefined;
+ * mtime: import("ipfs-unixfs/types/src/types").MtimeLike | undefined;
  * }, void, unknown>} File objects that match glob
  */
 module.exports = async function * globSource (cwd, pattern, options) {


### PR DESCRIPTION
Motivation:
* Fix https://github.com/ipfs/js-ipfs/issues/4080
* tl;dr
  * fix `import globSourceImport from 'ipfs-utils/src/files/glob-source.js'` from typescript
  * fix importing ipfs-core from typescript

Context:
* https://github.com/microsoft/TypeScript/issues/23857

Strategy
* Use jsdoc `@return` instead of `@yields` because tsc doesn't understand that `@yields` implies a `@return` type

Test Case
* https://github.com/gobengo/ipfs-core-esm-test/pull/3
* I tested locally with `npm link` and this seemed to fix it