### PR TITLE
fix: webpack dynamic require

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -9,10 +9,8 @@
 const { isElectronMain } = require('./env')
 
 // use window.fetch if it is available, fall back to node-fetch if not
-let impl = 'native-fetch'
-
 if (isElectronMain) {
-  impl = 'electron-fetch'
+  module.exports = require('electron-fetch')
+} else {
+  module.exports = require('native-fetch')
 }
-
-module.exports = require(impl)

--- a/src/http/fetch.js
+++ b/src/http/fetch.js
@@ -8,15 +8,10 @@
  * @property {globalThis.Headers} fetchImpl.Headers
  */
 
-let implName = './fetch.node'
-
 if (typeof XMLHttpRequest === 'function') {
   // Electron has `XMLHttpRequest` and should get the browser implementation
   // instead of node.
-  implName = './fetch.browser'
+  module.exports = require('./fetch.browser')
+} else {
+  module.exports = require('./fetch.node')
 }
-
-/** @type {fetchImpl} */
-const fetch = require(implName)
-
-module.exports = fetch


### PR DESCRIPTION
hi, I'd like to suggest a quick fix to building webpack-based node apps. Originally the bundle would fail to run with error messages like `Cannot find module './fetch.node'`, and it was due to that webpack could not handle `require()` statements with variables. Please feel free and let me know any feedback, thanks!