### PR TITLE
fix: specify duplex option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
+    time: "10:00"
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: "deps"
+    prefix-development: "deps(dev)"

--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [16]
+        node: [lts/*]
       fail-fast: true
     steps:
       - uses: actions/checkout@v3

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,4 @@
-The MIT License (MIT)
+This project is dual licensed under MIT and Apache-2.0.
 
-Copyright (c) IPFS
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+MIT: https://www.opensource.org/licenses/mit
+Apache-2.0: https://www.apache.org/licenses/license-2.0

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,52 @@
-# js-ipfs-utils  <!-- omit in toc -->
+# ipfs-utils <!-- omit in toc -->
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Build Status](https://github.com/ipfs/js-ipfs-utils/actions/workflows/js-test-and-release.yml/badge.svg?branch=main)](https://github.com/ipfs/js-ipfs-utils/actions/workflows/js-test-and-release.yml)
-[![Codecov branch](https://img.shields.io/codecov/c/github/ipfs/js-ipfs-utils/master.svg?style=flat-square)](https://codecov.io/gh/ipfs/js-ipfs-utils)
-[![Dependency Status](https://david-dm.org/ipfs/js-ipfs-utils.svg?style=flat-square)](https://david-dm.org/ipfs/js-ipfs-utils)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
+[![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)
+[![Discuss](https://img.shields.io/discourse/https/discuss.ipfs.tech/posts.svg?style=flat-square)](https://discuss.ipfs.tech)
+[![codecov](https://img.shields.io/codecov/c/github/ipfs/js-ipfs-utils.svg?style=flat-square)](https://codecov.io/gh/ipfs/js-ipfs-utils)
+[![CI](https://img.shields.io/github/actions/workflow/status/ipfs/js-ipfs-utils/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/ipfs/js-ipfs-utils/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
 
-> This package serves as a central repository for shared logic and dependencies for all IPFS packages, using `ipfs-utils` helps to easily re-use small scoped blocks of logic across all the js core interface implementations and also as a dependency proxy (think `aegir` for domain logic dependencies).
+> Package to aggregate shared logic and dependencies for the IPFS ecosystem
+
+## Table of contents <!-- omit in toc -->
+
+- [Install](#install)
+  - [Browser `<script>` tag](#browser-script-tag)
+- [Usage](#usage)
+- [API Docs](#api-docs)
+- [License](#license)
+- [Contribute](#contribute)
+
+## Install
+
+```console
+$ npm i ipfs-utils
+```
+
+### Browser `<script>` tag
+
+Loading this module through a script tag will make it's exports available as `IpfsUtils` in the global namespace.
+
+```html
+<script src="https://unpkg.com/ipfs-utils/dist/index.min.js"></script>
+```
 
 `ipfs-utils` aims to provide single function default export per file (with a few exceptions) scoped in 3 general categories:
--  General use
--  Data structs wrangling (arrays, objects, streams, etc)
--  IPFS core subsystems
+
+- General use
+- Data structs wrangling (arrays, objects, streams, etc)
+- IPFS core subsystems
 
 *General use* and *Data structs wrangling* should try to be just re-exports of community packages.
 
 The IPFS ecosystem has lots of repos with it comes several problems like:
+
 - Domain logic dedupe - all interface-core implementations shared a lot of logic like validation, streams handling, etc.
 - Dependencies management - it's really easy with so many repos for dependencies to go out of control, they become outdated, different repos use different modules to do the same thing (like merging defaults options), browser bundles ends up with multiple versions of the same package, bumping versions is cumbersome to do because we need to go through several repos, etc.
 
 These problems are the motivation for this package, having shared logic in this package avoids creating cyclic dependencies, centralizes common use modules/functions (exactly like aegir does for the tooling), semantic versioning for 3rd party dependencies is handled in one single place (a good example is going from streams 2 to 3) and maintainers should only care about having `ipfs-utils` updated.
 
-## Table of Contents <!-- omit in toc -->
-
-- [Install](#install)
-- [Usage](#usage)
-- [Functions](#functions)
-  - [General Use](#general-use)
-    - [TODO](#todo)
-  - [Data Struct Wrangling](#data-struct-wrangling)
-    - [TODO](#todo-1)
-  - [Core API](#core-api)
-    - [TODO](#todo-2)
-- [Contribute](#contribute)
-- [License](#license)
-
-## Install
-
-
-```bash
-$ npm install --save ipfs-utils
-```
-
 ## Usage
+
 Each function should be imported directly.
 
 ```js
@@ -54,22 +56,25 @@ validateAddInput(Buffer.from('test'))
 // true
 ```
 
-## Functions
+## API Docs
 
-### General Use
-#### TODO
-### Data Struct Wrangling
-#### TODO
-### Core API
-#### TODO
-
-
-## Contribute
-
-Contributions welcome. Please check out [the issues](https://github.com/ipfs/js-ipfs-utils/issues).
-
-Check out our [contributing document](https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to this repo are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+- <https://ipfs.github.io/js-ipfs-utils>
 
 ## License
 
-[MIT](LICENSE) © Protocol Labs Inc.
+Licensed under either of
+
+- Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+
+## Contribute
+
+Contributions welcome! Please check out [the issues](https://github.com/ipfs/js-ipfs-utils/issues).
+
+Also see our [contributing document](https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md) for more information on how we work, and about contributing in general.
+
+Please be aware that all interactions related to this repo are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -2,35 +2,44 @@
   "name": "ipfs-utils",
   "version": "9.0.9",
   "description": "Package to aggregate shared logic and dependencies for the IPFS ecosystem",
-  "main": "src/index.js",
   "author": "Hugo Dias <hugomrdias@gmail.com>",
-  "homepage": "https://github.com/ipfs/js-ipfs-utils",
-  "bugs": "https://github.com/ipfs/js-ipfs-utils/issues",
-  "repository": "github:ipfs/js-ipfs-utils",
+  "license": "Apache-2.0 OR MIT",
+  "homepage": "https://github.com/ipfs/js-ipfs-utils#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ipfs/js-ipfs-utils.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ipfs/js-ipfs-utils/issues"
+  },
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=7.0.0"
+  },
+  "main": "src/index.js",
+  "types": "dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*",
+        "dist/src/*"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist"
   ],
-  "browser": {
-    "./src/http/fetch.js": "./src/http/fetch.browser.js",
-    "./src/temp-dir.js": "./src/temp-dir.browser.js",
-    "./src/path-join.js": "./src/path-join.browser.js",
-    "./src/fetch.js": "./src/fetch.browser.js",
-    "./src/files/glob-source.js": false,
-    "./test/files/glob-source.spec.js": false,
-    "electron-fetch": false,
-    "fs": false
-  },
-  "react-native": {
-    "./src/fetch.js": "./src/fetch.rn.js",
-    "./src/http/fetch.js": "./src/http/fetch.rn.js"
-  },
-  "types": "dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "src/*": [
-        "dist/src/*"
-      ]
+  "eslintConfig": {
+    "extends": "ipfs",
+    "env": {
+      "worker": true
     }
   },
   "release": {
@@ -60,15 +69,15 @@
               "release": "patch"
             },
             {
-              "type": "chore",
-              "release": "patch"
-            },
-            {
               "type": "docs",
               "release": "patch"
             },
             {
               "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "deps",
               "release": "patch"
             },
             {
@@ -98,7 +107,11 @@
               },
               {
                 "type": "docs",
-                "section": "Trivial Changes"
+                "section": "Documentation"
+              },
+              {
+                "type": "deps",
+                "section": "Dependencies"
               },
               {
                 "type": "test",
@@ -115,6 +128,7 @@
     ]
   },
   "scripts": {
+    "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
     "build": "aegir build",
@@ -125,11 +139,12 @@
     "test:firefox-webworker": "npm run test -- -t webworker -- --browser firefox",
     "test:node": "npm run test -- -t node --cov",
     "test:electron-main": "npm run test -- -t electron-main",
-    "release": "semantic-release"
+    "release": "aegir release",
+    "docs": "aegir docs"
   },
-  "license": "MIT",
   "dependencies": {
     "any-signal": "^3.0.0",
+    "browser-readablestream-to-it": "^1.0.0",
     "buffer": "^6.0.1",
     "electron-fetch": "^1.7.2",
     "err-code": "^3.0.1",
@@ -138,10 +153,10 @@
     "it-glob": "^1.0.1",
     "it-to-stream": "^1.0.0",
     "merge-options": "^3.0.4",
-    "nanoid": "^3.1.20",
+    "nanoid": "^4.0.0",
     "native-fetch": "^3.0.0",
     "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-    "react-native-fetch-api": "^2.0.0",
+    "react-native-fetch-api": "^3.0.0",
     "stream-to-it": "^0.2.2"
   },
   "devDependencies": {
@@ -153,14 +168,23 @@
     "it-drain": "^1.0.3",
     "it-last": "^1.0.4",
     "react-native-polyfill-globals": "^3.0.0",
-    "readable-stream": "^3.6.0",
+    "readable-stream": "^4.3.0",
     "uint8arrays": "^3.0.0",
     "util": "^0.12.3"
   },
-  "eslintConfig": {
-    "extends": "ipfs",
-    "env": {
-      "worker": true
-    }
+  "browser": {
+    "./src/http/fetch.js": "./src/http/fetch.browser.js",
+    "./src/temp-dir.js": "./src/temp-dir.browser.js",
+    "./src/path-join.js": "./src/path-join.browser.js",
+    "./src/fetch.js": "./src/fetch.browser.js",
+    "./src/files/glob-source.js": false,
+    "./test/files/glob-source.spec.js": false,
+    "electron-fetch": false,
+    "node-fetch": false,
+    "fs": false
+  },
+  "react-native": {
+    "./src/fetch.js": "./src/fetch.rn.js",
+    "./src/http/fetch.js": "./src/http/fetch.rn.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "it-all": "^1.0.4",
     "it-drain": "^1.0.3",
     "it-last": "^1.0.4",
+    "it-to-buffer": "^2.0.0",
     "react-native-polyfill-globals": "^3.0.0",
     "readable-stream": "^4.3.0",
     "uint8arrays": "^3.0.0",

--- a/src/http.js
+++ b/src/http.js
@@ -137,7 +137,11 @@ class HTTP {
           signal,
           // @ts-expect-error non-browser fetch implementations may take extra options
           timeout: undefined,
-          headers
+          headers,
+
+          // https://fetch.spec.whatwg.org/#dom-requestinit-duplex
+          // https://github.com/whatwg/fetch/issues/1254
+          duplex: opts.body instanceof ReadableStream ? 'half' : undefined
         }
       ),
       opts.timeout,

--- a/src/http.js
+++ b/src/http.js
@@ -6,6 +6,9 @@ const { TimeoutError, HTTPError } = require('./http/error')
 const merge = require('merge-options').bind({ ignoreUndefined: true })
 const { URL, URLSearchParams } = require('iso-url')
 const anySignal = require('any-signal')
+const browserReableStreamToIt = require('browser-readablestream-to-it')
+const { isBrowser, isWebWorker } = require('./env')
+const all = require('it-all')
 
 /**
  * @typedef {import('stream').Readable} NodeReadableStream
@@ -127,6 +130,11 @@ class HTTP {
     // @ts-ignore
     const signal = anySignal([abortController.signal, opts.signal])
 
+    if (opts.body instanceof ReadableStream && (isBrowser || isWebWorker)) {
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1387483
+      opts.body = new Blob(await all(browserReableStreamToIt(opts.body)))
+    }
+
     /** @type {ExtendedResponse} */
     // @ts-expect-error additional fields are assigned below
     const response = await timeout(
@@ -141,7 +149,7 @@ class HTTP {
 
           // https://fetch.spec.whatwg.org/#dom-requestinit-duplex
           // https://github.com/whatwg/fetch/issues/1254
-          duplex: opts.body instanceof ReadableStream ? 'half' : undefined
+          duplex: 'half'
         }
       ),
       opts.timeout,
@@ -250,6 +258,10 @@ const ndjson = async function * (source) {
  * @returns {AsyncIterable<TChunk>}
  */
 const fromStream = (source) => {
+  if (isAsyncIterable(source)) {
+    return source
+  }
+
   // Workaround for https://github.com/node-fetch/node-fetch/issues/766
   if (isNodeReadableStream(source)) {
     const iter = source[Symbol.asyncIterator]()
@@ -270,27 +282,7 @@ const fromStream = (source) => {
   }
 
   if (isWebReadableStream(source)) {
-    const reader = source.getReader()
-    return (async function * () {
-      try {
-        while (true) {
-          // Read from the stream
-          const { done, value } = await reader.read()
-          // Exit if we're done
-          if (done) return
-          // Else yield the chunk
-          if (value) {
-            yield value
-          }
-        }
-      } finally {
-        reader.releaseLock()
-      }
-    })()
-  }
-
-  if (isAsyncIterable(source)) {
-    return source
+    return browserReableStreamToIt(source)
   }
 
   throw new TypeError('Body can\'t be converted to AsyncIterable')

--- a/src/http.js
+++ b/src/http.js
@@ -130,7 +130,7 @@ class HTTP {
     // @ts-ignore
     const signal = anySignal([abortController.signal, opts.signal])
 
-    if (opts.body instanceof ReadableStream && (isBrowser || isWebWorker)) {
+    if (globalThis.ReadableStream != null && opts.body instanceof globalThis.ReadableStream && (isBrowser || isWebWorker)) {
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1387483
       opts.body = new Blob(await all(browserReableStreamToIt(opts.body)))
     }

--- a/src/http/fetch.node.js
+++ b/src/http/fetch.node.js
@@ -1,5 +1,6 @@
 'use strict'
-const { Request, Response, Headers, default: nativeFetch } = require('../fetch')
+// @ts-expect-error Request, Response and Headers are global types but concrete in implementations
+const { Request, Response, Headers, default: defaultFetch, fetch: fetchFetch } = require('../fetch')
 // @ts-ignore
 const toStream = require('it-to-stream')
 const { Buffer } = require('buffer')
@@ -9,6 +10,9 @@ const { Buffer } = require('buffer')
  * @typedef {import('../types').FetchOptions} FetchOptions
  * @typedef {import('../types').ProgressFn} ProgressFn
  */
+
+// undici and node-fetch have different exports
+const nativeFetch = defaultFetch ?? fetchFetch
 
 /**
  * @param {string|Request} url

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -70,9 +70,13 @@ describe('http', function () {
   })
 
   it('makes a ReadableStream request', async () => {
+    if (globalThis.ReadableStream == null) {
+      return
+    }
+
     const data = 'hello world'
 
-    const body = new ReadableStream({
+    const body = new globalThis.ReadableStream({
       start (controller) {
         controller.enqueue(data)
         controller.close()

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -158,15 +158,14 @@ describe('http', function () {
     this.timeout(10000)
     let upload = 0
     const body = new Uint8Array(1000000 / 2)
+    let progressInfo
     const request = await HTTP.post(`${ECHO_SERVER}/echo`, {
       body,
       headers: {
         'Content-Type': 'application/octet-stream'
       },
       onUploadProgress: (progress) => {
-        expect(progress).to.have.property('lengthComputable').to.be.a('boolean')
-        expect(progress).to.have.property('total', body.byteLength)
-        expect(progress).to.have.property('loaded').that.is.greaterThan(0)
+        progressInfo = progress
         upload += 1
       }
     })
@@ -175,6 +174,9 @@ describe('http', function () {
     expect(uint8ArrayEquals(out, body))
 
     expect(upload).to.be.greaterThan(0)
+    expect(progressInfo).to.have.property('lengthComputable').to.be.a('boolean')
+    expect(progressInfo).to.have.property('total').to.be.a('number')
+    expect(progressInfo).to.have.property('loaded').that.is.greaterThan(0)
   })
 
   it('makes a GET request with unprintable characters', async function () {

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -11,8 +11,10 @@ const all = require('it-all')
 const { isBrowser, isWebWorker, isReactNative } = require('../src/env')
 const { Buffer } = require('buffer')
 const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
+const { toString: uint8ArrayToString } = require('uint8arrays/to-string')
 const { equals: uint8ArrayEquals } = require('uint8arrays/equals')
 const { concat: uint8ArrayConcat } = require('uint8arrays/concat')
+const toBuffer = require('it-to-buffer')
 
 const ECHO_SERVER = process.env.ECHO_SERVER || ''
 
@@ -65,6 +67,24 @@ describe('http', function () {
 
     const out = await req.text()
     expect(out).to.be.eq('{"test":2}')
+  })
+
+  it('makes a ReadableStream request', async () => {
+    const data = 'hello world'
+
+    const body = new ReadableStream({
+      start (controller) {
+        controller.enqueue(data)
+        controller.close()
+      }
+    })
+
+    const req = await HTTP.post(`${ECHO_SERVER}/echo`, {
+      body
+    })
+
+    const out = uint8ArrayToString(await toBuffer(req.iterator()))
+    expect(out).to.equal('hello world')
   })
 
   it('makes a DELETE request', async () => {


### PR DESCRIPTION
A recent change to the fetch spec means the `duplex` option has to be set to `half` when using a `ReadbleStream` as the request body.